### PR TITLE
Improve tests

### DIFF
--- a/.github/workflows/rspec.yaml
+++ b/.github/workflows/rspec.yaml
@@ -18,7 +18,7 @@ jobs:
         run: ./install.sh
 
       - name: Configure
-        run: cd ./tests && ./prepare.rb "http://${ONE}:2633/RPC2" "http://${ONE}:2474" 0 1
+        run: cd ./tests && ./prepare.rb "http://${{ env.ONE }}:2633/RPC2" "http://${{ env.ONE }}:2474" 0 1
 
       # Maybe should be included in rspec
       - name: Start engine

--- a/.github/workflows/rspec.yaml
+++ b/.github/workflows/rspec.yaml
@@ -8,9 +8,8 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ruby-version: ['3.2']
+    env:
+      ONE: "3.72.81.234" # opennebula endpoint to be used by the PE runner
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -19,7 +18,7 @@ jobs:
         run: ./install.sh
 
       - name: Configure
-        run: cd ./tests && ./prepare.rb http://3.72.81.234:2633/RPC2 http://3.72.81.234:2474 0 1
+        run: cd ./tests && ./prepare.rb "http://${ONE}:2633/RPC2" "http://${ONE}:2474" 0 1
 
       # Maybe should be included in rspec
       - name: Start engine

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Provisioning Engine
 
-[![Test](https://github.com/dann1/provisioning-engine/actions/workflows/rspec.yaml/badge.svg)](https://github.com/dann1/provisioning-engine/actions/workflows/rspec.yaml)
+[![Test](https://github.com/SovereignEdgeEU-COGNIT/provisioning-engine/actions/workflows/rspec.yaml/badge.svg)](https://github.com/SovereignEdgeEU-COGNIT/provisioning-engine/actions/workflows/rspec.yaml)
 
 Provisioning Engine acts as a entry point for the Device Runtime, instructs the Cloud-Edge Manager to spawn new FaaS/DaaS Runtimes and returns the endpoint back to the device. Afterwards, manages the lifetime of the FaaS/DaaS Runtimes
 

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -84,7 +84,7 @@ describe 'Provision Engine API' do
     end
 
     it "should delete a #{SR}" do
-        attempts = 10
+        attempts = 30
 
         1.upto(attempts) do |t|
             sleep 1


### PR DESCRIPTION
- OpenNebula endpoint is now a variable. Makes it easier to update the tests depending on the target env
- Delete attempts are now 30 to prevent slow flows becoming a problem for test results
- Badge now points to this repository workflow executions. The result of this test should fail because that host doesn't exist anymore. Delete last workflow run