### PR TITLE
Target Cognit frontend for gh actions

### DIFF
--- a/.github/workflows/rspec.yaml
+++ b/.github/workflows/rspec.yaml
@@ -9,7 +9,11 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     env:
-      ONE: "3.72.81.234" # opennebula endpoint to be used by the PE runner
+      oned: https://cognit-lab.sovereignedge.eu/RPC2
+      oneflow: https://cognit-lab-oneflow.sovereignedge.eu/
+      nature: 2
+      nature_s3: 4 # still not configured on the frontend nor it runs in the tests
+      TESTS_AUTH: ${{ secrets.TESTS_AUTH }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -18,7 +22,7 @@ jobs:
         run: ./install.sh
 
       - name: Configure
-        run: cd ./tests && ./prepare.rb "http://${{ env.ONE }}:2633/RPC2" "http://${{ env.ONE }}:2474" 0 1
+        run: cd ./tests && ./prepare.rb "${{ env.oned }}" "${{ env.oneflow }}" "${{ env.nature }}" "${{ env.nature_s3 }}"
 
       # Maybe should be included in rspec
       - name: Start engine

--- a/tests/conf.yaml
+++ b/tests/conf.yaml
@@ -1,2 +1,3 @@
-:engine_endpoint: 'http://localhost:1337/' # TODO: load from engine.conf
-:auth: 'oneadmin:opennebula'
+:timeouts:
+  :get: 120
+  :delete: 30

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -18,9 +18,11 @@ require_relative '../src/server/runtime'
 
 SR = 'Serverless Runtime'
 
-conf = YAML.load_file('./conf.yaml')
-endpoint = conf[:engine_endpoint] || 'http://localhost:1337/'
-auth = conf[:auth] || 'oneadmin:opennebula'
+conf_engine = YAML.load_file('/etc/provision-engine/engine.conf')
+endpoint = "http://#{conf_engine[:host]}:#{conf_engine[:port]}"
+
+conf_tests = YAML.load_file('./conf.yaml')
+auth = ENV['TESTS_AUTH'] || 'oneadmin:opennebula'
 
 engine_client = ProvisionEngine::Client.new(endpoint, auth)
 
@@ -51,9 +53,10 @@ describe 'Provision Engine API' do
     end
 
     it "should get #{SR} info" do
-        attempts = 30
+        attempts = conf_tests[:timeouts][:get]
 
         1.upto(attempts) do |t|
+            sleep 1
             expect(t == attempts).to be(false)
 
             response = engine_client.get(id)
@@ -84,11 +87,10 @@ describe 'Provision Engine API' do
     end
 
     it "should delete a #{SR}" do
-        attempts = 30
+        attempts = conf_tests[:timeouts][:get]
 
         1.upto(attempts) do |t|
             sleep 1
-
             expect(t == attempts).to be(false)
 
             response = engine_client.delete(id)


### PR DESCRIPTION
[A secret](https://github.com/SovereignEdgeEU-COGNIT/provisioning-engine/settings/secrets/actions) was added containing the auth required for the tests CloudClient. It holds the oneadmin user credentials. Even though the credential is behind a secret, an extra limitation by placing the tests to run under a different non oneadmin user with limited access just to perform the tests would bring extra security.