### PR TITLE
Fix return values for Create and Get

### DIFF
--- a/src/server/runtime.rb
+++ b/src/server/runtime.rb
@@ -17,6 +17,9 @@ module ProvisionEngine
                     :NAME => {
                         :type => 'string'
                     },
+                    :ID => {
+                        :type => 'integer'
+                    },
                     :FAAS => {
                         :type => 'object',
                     :properties => {
@@ -36,30 +39,30 @@ module ProvisionEngine
                     :required => ['FLAVOUR']
                     },
                     :DAAS => {
-                       'oneOf' => [
-                         {
-                           :type => 'object',
-                           :properties => {
-                             :CPU => {
-                               :type => 'integer'
-                             },
-                             :MEMORY => {
-                               :type => 'integer'
-                             },
-                             :DISK_SIZE => {
-                               :type => 'integer'
-                             },
-                             :FLAVOUR => {
-                               :type => 'string'
-                             }
-                           },
-                           :required => ['FLAVOUR']
-                         },
-                         {
-                           :type =>  'null'
-                         }
-                       ]
-                     },
+                        'oneOf' => [
+                            {
+                                :type => 'object',
+                              :properties => {
+                                  :CPU => {
+                                      :type => 'integer'
+                                  },
+                                :MEMORY => {
+                                    :type => 'integer'
+                                },
+                                :DISK_SIZE => {
+                                    :type => 'integer'
+                                },
+                                :FLAVOUR => {
+                                    :type => 'string'
+                                }
+                              },
+                              :required => ['FLAVOUR']
+                            },
+                            {
+                                :type =>  'null'
+                            }
+                        ]
+                    },
                     :SCHEDULING => {
                         :type => 'object',
                     :properties => {

--- a/src/server/runtime.rb
+++ b/src/server/runtime.rb
@@ -213,9 +213,22 @@ module ProvisionEngine
                     :ID => id
                 }
             }
+            rsr = runtime[:SERVERLESS_RUNTIME]
 
-            runtime[:SERVERLESS_RUNTIME].merge!(@body)
-            runtime[:SERVERLESS_RUNTIME].delete('registration_time')
+            rsr.merge!(@body)
+            rsr.delete('registration_time')
+
+            ['FAAS', 'DAAS'].each do |role|
+                next unless rsr[role]
+
+                ['MEMORY', 'DISK_SIZE'].each do |param|
+                    rsr[role][param] = rsr[role][param].to_i
+                end
+
+                ['CPU'].each do |param|
+                    rsr[role][param] = rsr[role][param].to_f
+                end
+            end
 
             runtime
         end

--- a/src/server/runtime.rb
+++ b/src/server/runtime.rb
@@ -20,6 +20,9 @@ module ProvisionEngine
                     :ID => {
                         :type => 'integer'
                     },
+                    :SERVICE_ID => {
+                        :type => 'integer'
+                    },
                     :FAAS => {
                         :type => 'object',
                     :properties => {
@@ -214,9 +217,10 @@ module ProvisionEngine
                 }
             }
             rsr = runtime[:SERVERLESS_RUNTIME]
-
             rsr.merge!(@body)
+
             rsr.delete('registration_time')
+            rsr['SERVICE_ID'] = rsr['SERVICE_ID'].to_i
 
             ['FAAS', 'DAAS'].each do |role|
                 next unless rsr[role]

--- a/src/server/runtime.rb
+++ b/src/server/runtime.rb
@@ -24,7 +24,7 @@ module ProvisionEngine
                         :type => 'object',
                     :properties => {
                         :CPU => {
-                            :type => 'integer'
+                            :type => 'number'
                         },
                         :MEMORY => {
                             :type => 'integer'
@@ -44,7 +44,7 @@ module ProvisionEngine
                                 :type => 'object',
                               :properties => {
                                   :CPU => {
-                                      :type => 'integer'
+                                      :type => 'number'
                                   },
                                 :MEMORY => {
                                     :type => 'integer'

--- a/src/server/runtime.rb
+++ b/src/server/runtime.rb
@@ -128,7 +128,8 @@ module ProvisionEngine
             client.logger.info("Created #{SR} Document")
 
             runtime.info
-            [201, runtime]
+
+            [201, runtime.to_sr]
         end
 
         def self.get(client, id)
@@ -145,7 +146,7 @@ module ProvisionEngine
             ServerlessRuntime.service_sync(client, runtime.body, service_id)
             runtime.update
 
-            [200, runtime]
+            [200, runtime.to_sr]
         end
 
         def delete
@@ -197,6 +198,27 @@ module ProvisionEngine
         #################
         # Helpers
         #################
+
+        #
+        # Translates the Serverless Runtime document to the SCHEMA
+        #
+        # @return [Hash] Serverless Runtime definition
+        #
+        def to_sr
+            load_body if @body.nil?
+
+            runtime = {
+                :SERVERLESS_RUNTIME => {
+                    :NAME => name,
+                    :ID => id
+                }
+            }
+
+            runtime[:SERVERLESS_RUNTIME].merge!(@body)
+            runtime[:SERVERLESS_RUNTIME].delete('registration_time')
+
+            runtime
+        end
 
         #
         # Updates Serverless Runtime Document specification based on the underlying elements state

--- a/src/server/runtime.rb
+++ b/src/server/runtime.rb
@@ -129,7 +129,7 @@ module ProvisionEngine
 
             runtime.info
 
-            [201, runtime.to_sr]
+            [201, runtime]
         end
 
         def self.get(client, id)
@@ -146,7 +146,7 @@ module ProvisionEngine
             ServerlessRuntime.service_sync(client, runtime.body, service_id)
             runtime.update
 
-            [200, runtime.to_sr]
+            [200, runtime]
         end
 
         def delete

--- a/src/server/server.rb
+++ b/src/server/server.rb
@@ -134,7 +134,7 @@ post '/serverless-runtimes' do
     case rc
     when 201
         log_response('info', rc, rb, "#{SR} created")
-        json_response(rc, rb)
+        json_response(rc, rb.to_sr)
     when 400
         log_response('error', rc, rb, "Invalid #{SRD}")
         halt rc, json_response(rc, rb)
@@ -171,7 +171,7 @@ get '/serverless-runtimes/:id' do
     case rc
     when 200
         log_response('info', rc, rb, SR)
-        json_response(rc, rb)
+        json_response(rc, rb.to_sr)
     when 401
         log_response('error', rc, rb, NO_AUTH)
         halt rc, json_response(rc, rb)

--- a/tests/example_runtime_definition.json
+++ b/tests/example_runtime_definition.json
@@ -5,13 +5,13 @@
       "CPU": 1,
       "MEMORY": 128,
       "DISK_SIZE": 1024,
-      "FLAVOUR": "nature"
+      "FLAVOUR": "Function"
     },
     "DAAS": {
       "CPU": 1,
       "MEMORY": 128,
       "DISK_SIZE": 1024,
-      "FLAVOUR": "s3"
+      "FLAVOUR": "Data"
     },
     "SCHEDULING": {},
     "DEVICE_INFO": {}

--- a/tests/example_runtime_definition_minimal.json
+++ b/tests/example_runtime_definition_minimal.json
@@ -1,7 +1,7 @@
 {
   "SERVERLESS_RUNTIME": {
     "FAAS": {
-      "FLAVOUR": "nature"
+      "FLAVOUR": "Function"
     },
     "SCHEDULING": {},
     "DEVICE_INFO": {}

--- a/tests/prepare.rb
+++ b/tests/prepare.rb
@@ -20,6 +20,7 @@ def configure_engine(oned, oneflow)
     # Update the values
     config[:one_xmlrpc] = oned if oned
     config[:oneflow_server] = oneflow if oneflow
+    config[:log][:level] = 0
 
     tempfile = Tempfile.new('engine.conf')
     tempfile.write(config)

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -98,4 +98,14 @@ describe 'Provision Engine API' do
             break
         end
     end
+
+    it 'prints every log' do
+        logcation = '/var/log/provision-engine'
+
+        pp '-----------------------------------'
+        pp File.read("#{logcation}/engine.log")
+        pp '-----------------------------------'
+        pp File.read("#{logcation}/api.log")
+        pp '-----------------------------------'
+    end
 end

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -38,13 +38,12 @@ describe 'Provision Engine API' do
 
         expect(response.code.to_i).to eq(201)
 
-        document = JSON.parse(response.body)
-        pp document
+        runtime = JSON.parse(response.body)
+        pp runtime
 
-        id = document['DOCUMENT']['ID'].to_i
-        body = runtime_body(document)
+        id = runtime['SERVERLESS_RUNTIME']['ID'].to_i
 
-        validation = ProvisionEngine::ServerlessRuntime.validate(body)
+        validation = ProvisionEngine::ServerlessRuntime.validate(runtime)
         pp validation[1]
 
         expect(validation[0]).to be(true)
@@ -61,13 +60,11 @@ describe 'Provision Engine API' do
 
             expect(response.code.to_i).to eq(200)
 
-            document = JSON.parse(response.body)
-            pp document
-
-            body = runtime_body(document)
+            runtime = JSON.parse(response.body)
+            pp runtime
 
             # Even though the VM reaches RUNNING, the service might not
-            next unless body['FAAS']['STATE'] == 'ACTIVE'
+            next unless runtime['SERVERLESS_RUNTIME']['FAAS']['STATE'] == 'ACTIVE'
 
             break
         end
@@ -101,8 +98,4 @@ describe 'Provision Engine API' do
             break
         end
     end
-end
-
-def runtime_body(document)
-    document['DOCUMENT']['TEMPLATE']['BODY']
 end


### PR DESCRIPTION
Now returns

```json
 ~/P/C/provisioning-engine   sr_return *  src/client  ./http_cli.rb get http://localhost:1337/serverless-runtimes/230 ../../tests/example_runtime_definition_minimal.json
{
  "SERVERLESS_RUNTIME": {
    "NAME": "nature_aafdcada-cfe8-4b8c-87ed-af42de44b81c",
    "ID": 240,
    "FAAS": {
      "FLAVOUR": "nature",
      "ENDPOINT": "http://localhost:1339",
      "VM_ID": "205",
      "STATE": "PENDING",
      "CPU": 0.1,
      "MEMORY": 64,
      "DISK_SIZE": 256
    },
    "SCHEDULING": {
    },
    "DEVICE_INFO": {
    },
    "SERVICE_ID": 239
  }
}
```

Other changes

- Fixed schema having wrong parameter types and missing parameters
- Tests updated
	- backported verbose logging  from dev branch
	- run tests on dedicated test templates to avoid NIC lease problems