### PR TITLE
Fix ENDPOINT

### DIFF
--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -101,11 +101,12 @@ describe 'Provision Engine API' do
 
     it 'prints every log' do
         logcation = '/var/log/provision-engine'
+        sep = '-----------------------------------'
+        log_files = ['engine', 'api', 'CloudClient']
 
-        pp '-----------------------------------'
-        pp File.read("#{logcation}/engine.log")
-        pp '-----------------------------------'
-        pp File.read("#{logcation}/api.log")
-        pp '-----------------------------------'
+        log_files.each do |log_file|
+            pp File.read("#{logcation}/#{log_file}.log")
+            pp sep
+        end
     end
 end


### PR DESCRIPTION
Now instead of pointing to `oneflow_server` it points to the IP address of the NIC0 in the VM that holds the function.

Also
- last CloudClient log entry is printed to the test output
- Removed conversion logic from `to_sr` as it can be done better on the document creation, thus having correct schema compliance on the document_pool table and requiring only one conversion.