### PR TITLE
VM, Service improved and extended verifications

### DIFF
--- a/src/server/runtime.rb
+++ b/src/server/runtime.rb
@@ -169,11 +169,15 @@ module ProvisionEngine
             service_id = document['DOCUMENT']['TEMPLATE']['BODY']['SERVICE_ID']
             response = cclient.service_delete(service_id)
             rc = response[0]
+            rb = response[1]
 
-            if rc == 404
-                cclient.logger.warning("Cannot find #{SR} Service")
-            elsif rc != 204
-                rb = response[1]
+            if rc != 204
+                if rc == 404
+                    cclient.logger.warning("Cannot find #{SR} Service")
+                elsif rc == 500 && rb == 'Service cannot be undeployed in state: DEPLOYING'
+                    rc = 423
+                    rb = "#{SR} has not finished deployment"
+                end
                 return [rc, rb]
             end
 

--- a/src/server/server.rb
+++ b/src/server/server.rb
@@ -31,6 +31,7 @@ SRD = "#{SR} definition".freeze
 DENIED = 'Permission denied'.freeze
 NO_AUTH = 'Failed to authenticate in OpenNebula'.freeze
 SR_NOT_FOUND = "#{SR} not found".freeze
+NO_DELETE = "Failed to delete #{SR}".freeze
 
 # Helper method to return JSON responses
 def json_response(response_code, data)
@@ -232,8 +233,11 @@ delete '/serverless-runtimes/:id' do
         when 403
             log_response('error', rc, rb, DENIED)
             halt rc, json_response(rc, rb)
+        when 423
+            log_response('error', rc, rb, NO_DELETE)
+            halt rc, json_response(rc, rb)
         else
-            log_response('error', rc, rb, "Failed to delete #{SR}")
+            log_response('error', rc, rb, NO_DELETE)
             halt 500, json_response(500, rb)
         end
     when 401
@@ -246,7 +250,7 @@ delete '/serverless-runtimes/:id' do
         log_response('error', rc, rb, SR_NOT_FOUND)
         halt rc, json_response(rc, rb)
     else
-        log_response('error', rc, rb, "Failed to delete #{SR}")
+        log_response('error', rc, rb, NO_DELETE)
         halt 500, json_response(500, rb)
     end
 end

--- a/tests/init.rb
+++ b/tests/init.rb
@@ -47,10 +47,7 @@ rspec_conf = {
     :endpoint => endpoint
 }
 
-RSpec.configure do |c|
-    c.add_setting :rspec
-    c.before { @conf = rspec_conf }
-end
+RSpec.configure {|c| c.before { @conf = rspec_conf } }
 
 ############################################################################
 # Run tests

--- a/tests/init.rb
+++ b/tests/init.rb
@@ -19,12 +19,11 @@ require_relative '../src/client/client'
 require_relative '../src/server/runtime'
 
 $LOAD_PATH << "#{__dir__}/lib" # Test libraries
+require 'common'
 require 'log'
 require 'crud'
 require 'auth'
 require 'crud_invalid'
-
-SR = 'Serverless Runtime'
 
 ############################################################################
 # Initialize rspec configuration
@@ -54,14 +53,6 @@ RSpec.configure do |c|
 end
 
 ############################################################################
-# RSPEC methods
-############################################################################
-
-def examples?(examples, conf, params = nil)
-    include_context(examples, params) if conf[:examples][examples]
-end
-
-############################################################################
 # Run tests
 ############################################################################
 RSpec.describe 'Provision Engine API' do
@@ -79,31 +70,4 @@ RSpec.describe 'Provision Engine API' do
     end
 
     examples?('inspect logs', rspec_conf[:conf])
-end
-
-############################################################################
-# Helpers
-############################################################################
-
-def random_string
-    chars = ('a'..'z').to_a + ('A'..'Z').to_a
-    string = ''
-    8.times { string << chars[SecureRandom.rand(chars.size)] }
-    string
-end
-
-def random_faas_minimal
-    flavour = random_string
-    pp "rolled a random flavour #{flavour}"
-
-    {
-        :SERVERLESS_RUNTIME => {
-            :NAME => flavour,
-            :FAAS => {
-                :FLAVOUR => flavour
-            },
-            :SCHEDULING => {},
-            :DEVICE_INFO => {}
-        }
-    }
 end

--- a/tests/init.rb
+++ b/tests/init.rb
@@ -10,14 +10,15 @@ require 'securerandom'
 # Gems
 require 'rspec'
 require 'rack/test'
+require 'json-schema'
+require 'opennebula'
+require 'opennebula/oneflow_client'
 
 # Engine libraries
-require 'opennebula'
-require 'json-schema'
 require_relative '../src/client/client'
 require_relative '../src/server/runtime'
 
-$LOAD_PATH << "#{__dir__}/lib"
+$LOAD_PATH << "#{__dir__}/lib" # Test libraries
 require 'log'
 require 'crud'
 require 'auth'
@@ -31,11 +32,19 @@ SR = 'Serverless Runtime'
 conf_engine = YAML.load_file('/etc/provision-engine/engine.conf')
 endpoint = "http://#{conf_engine[:host]}:#{conf_engine[:port]}"
 auth = ENV['TESTS_AUTH'] || 'oneadmin:opennebula'
-engine_client = ProvisionEngine::Client.new(endpoint, auth)
+flow_client_args = {
+    :url => conf_engine[:oneflow_server],
+    :username => auth.split(':')[0],
+    :password => auth.split(':')[-1]
+}
 
 rspec_conf = {
     :conf => YAML.load_file('./conf.yaml'),
-    :engine_client => engine_client,
+    :client => {
+        :engine => ProvisionEngine::Client.new(endpoint, auth),
+        :oned => OpenNebula::Client.new(auth, conf_engine[:one_xmlrpc]),
+        :oneflow => Service::Client.new(flow_client_args)
+    },
     :endpoint => endpoint
 }
 
@@ -57,23 +66,6 @@ end
 ############################################################################
 RSpec.describe 'Provision Engine API' do
     include Rack::Test::Methods
-
-    def wait_delete(sr_id)
-        attempts = @conf[:conf][:timeouts][:get]
-        1.upto(attempts) do |t|
-            sleep 1
-            expect(t == attempts).to be(false)
-
-            response = @conf[:engine_client].delete(sr_id)
-            rc = response.code
-
-            next unless rc == 204
-
-            expect(rc).to eq(204)
-
-            break
-        end
-    end
 
     examples?('auth', rspec_conf[:conf])
     examples?('crud_invalid', rspec_conf[:conf])

--- a/tests/lib/auth.rb
+++ b/tests/lib/auth.rb
@@ -1,6 +1,12 @@
 RSpec.shared_context 'auth' do
-    it 'permission denied on Create' do
+    it 'permission denied on Create service_template' do
         response = @conf[:client][:engine].create(random_faas_minimal)
+        expect([403, 422].include?(response.code)).to be(true)
+    end
+
+    it 'permission denied on Create vm_template' do
+        specification = JSON.load_file('templates/sr_faas_denyVMTemplate.json')
+        response = @conf[:client][:engine].create(specification)
         expect([403, 422].include?(response.code)).to be(true)
     end
 

--- a/tests/lib/auth.rb
+++ b/tests/lib/auth.rb
@@ -5,7 +5,16 @@ RSpec.shared_context 'auth' do
     end
 
     it 'permission denied on Create vm_template' do
-        specification = JSON.load_file('templates/sr_faas_denyVMTemplate.json')
+        specification = {
+            'SERVERLESS_RUNTIME' => {
+                'FAAS' => {
+                    'FLAVOUR' => 'DenyVMTemplate'
+                },
+                'SCHEDULING' => {},
+                'DEVICE_INFO' => {}
+            }
+        }
+
         response = @conf[:client][:engine].create(specification)
         expect([403, 422].include?(response.code)).to be(true)
     end

--- a/tests/lib/auth.rb
+++ b/tests/lib/auth.rb
@@ -1,6 +1,6 @@
 RSpec.shared_context 'auth' do
     it 'permission denied on Create' do
-        response = @conf[:engine_client].create(random_faas_minimal)
+        response = @conf[:client][:engine].create(random_faas_minimal)
         expect([403, 422].include?(response.code)).to be(true)
     end
 
@@ -9,7 +9,7 @@ RSpec.shared_context 'auth' do
         @conf[:auth][:sr_template] = JSON.load_file('templates/sr_faas_minimal.json')
         @conf[:auth][:engine_client_no_auth] = ProvisionEngine::Client.new(@conf[:endpoint])
 
-        response = @conf[:engine_client].create(@conf[:auth][:sr_template])
+        response = @conf[:client][:engine].create(@conf[:auth][:sr_template])
 
         expect(response.code).to eq(201)
         @conf[:auth][:create] = true
@@ -73,6 +73,6 @@ RSpec.shared_context 'auth' do
     it "delete #{SR} after auth tests have concluded" do
         skip "#{SR} creation failed" unless @conf[:auth][:create]
 
-        wait_delete(@conf[:auth][:id])
+        verify_sr_delete(@conf[:auth][:id])
     end
 end

--- a/tests/lib/auth.rb
+++ b/tests/lib/auth.rb
@@ -1,21 +1,11 @@
 RSpec.shared_context 'auth' do
     it 'permission denied on Create service_template' do
-        response = @conf[:client][:engine].create(random_faas_minimal)
+        response = @conf[:client][:engine].create(generate_faas_minimal)
         expect([403, 422].include?(response.code)).to be(true)
     end
 
     it 'permission denied on Create vm_template' do
-        specification = {
-            'SERVERLESS_RUNTIME' => {
-                'FAAS' => {
-                    'FLAVOUR' => 'DenyVMTemplate'
-                },
-                'SCHEDULING' => {},
-                'DEVICE_INFO' => {}
-            }
-        }
-
-        response = @conf[:client][:engine].create(specification)
+        response = @conf[:client][:engine].create(generate_faas_minimal('DenyVMTemplate'))
         expect([403, 422].include?(response.code)).to be(true)
     end
 

--- a/tests/lib/common.rb
+++ b/tests/lib/common.rb
@@ -88,13 +88,13 @@ def verify_sr_delete(sr_id)
             when 500
                 raise 'Server error, check logs'
             else
-                raise "Unexpected error code: #{rc}"
+                raise "Unexpected error code: #{response.code}"
             end
         end
     when 500
         raise 'Server error, check logs'
     else
-        raise "Unexpected error code: #{rc}"
+        raise "Unexpected error code: #{response.code}"
     end
 end
 

--- a/tests/lib/common.rb
+++ b/tests/lib/common.rb
@@ -124,10 +124,11 @@ def random_string
     string
 end
 
-def random_faas_minimal
-    flavour = random_string
-    pp "rolled a random flavour #{flavour}"
-
+def generate_faas_minimal(flavour = nil)
+    if !flavour
+        flavour = random_string
+        pp "rolled a random flavour #{flavour}"
+    end
     {
         'SERVERLESS_RUNTIME' => {
             'NAME' => flavour,

--- a/tests/lib/common.rb
+++ b/tests/lib/common.rb
@@ -1,0 +1,141 @@
+SR = 'Serverless Runtime'.freeze
+
+############################################################################
+# RSpec methods
+############################################################################
+
+def examples?(examples, conf, params = nil)
+    include_context(examples, params) if conf[:examples][examples]
+end
+
+def verify_sr_spec(specification, runtime)
+    [specification, runtime].each do |sr|
+        schema_ok = ProvisionEngine::ServerlessRuntime.validate(sr)
+
+        raise schema_ok[1] unless schema_ok[0]
+    end
+
+    specification = specification['SERVERLESS_RUNTIME']
+    runtime = runtime['SERVERLESS_RUNTIME']
+
+    # optional name has been applied if given
+    expect(runtime['NAME']).to eq(specification['NAME']) if specification['NAME']
+
+    # mandatory information is present on SR object
+    ['SERVICE_ID', 'DEVICE_INFO', 'SCHEDULING'].each do |mandatory|
+        expect(runtime.key?(mandatory)).to be(true)
+    end
+
+    # service has been created
+    response = @conf[:client][:oneflow].get("/service/#{runtime['SERVICE_ID']}")
+    expect(response.code.to_i).to eq(200)
+
+    ['FAAS', 'DAAS'].each do |role|
+        next unless specification[role]
+
+        vm = OpenNebula::VirtualMachine.new_with_id(runtime[role]['VM_ID'], @conf[:client][:oned])
+        raise "Error getting #{SR} VM" if OpenNebula.is_error?(vm.info)
+
+        # mandatory role information exists
+        ['FLAVOUR', 'VM_ID', 'STATE', 'ENDPOINT'].each do |mandatory|
+            expect(runtime[role].key?(mandatory)).to be(true)
+        end
+
+        # optional role information exists if given
+        ['CPU', 'VCPU', 'MEMORY', 'DISK_SIZE'].each do |optional|
+            next unless specification[role][optional]
+
+            expect(runtime[role][optional]).to eq(specification[role][optional])
+        end
+
+        # rubocop:disable Style/StringLiterals
+        # verify VM has correct resources
+        ['CPU', 'VCPU', 'MEMORY'].each do |capacity|
+            next unless specification[role][capacity]
+
+            expect(vm["//TEMPLATE/#{capacity}"].to_f).to eq(specification[role][capacity].to_f)
+        end
+
+        expect(runtime[role]['ENDPOINT']).to eq(vm["//TEMPLATE/NIC[NIC_ID=\"0\"]/IP"])
+
+        if specification[role]['DISK_SIZE']
+            expect(vm["//TEMPLATE/DISK[DISK_ID=\"0\"]/SIZE"].to_i).to eq(specification[role]['DISK_SIZE'])
+        end
+        # rubocop:enable Style/StringLiterals
+    end
+end
+
+def verify_sr_delete(sr_id)
+    response = @conf[:client][:engine].delete(sr_id)
+
+    case response.code
+    when 204
+        verify_service_delete(sr_id)
+    when 423
+        attempts = @conf[:conf][:timeouts][:get]
+        1.upto(attempts) do |t|
+            expect(t <= attempts).to be(true)
+            sleep 1
+
+            response = @conf[:client][:engine].delete(sr_id)
+            case response.code
+            when 423
+                pp "Waiting for #{SR} to reach end state"
+                next
+            when 204
+                verify_service_delete(sr_id)
+                break
+            when 500
+                raise 'Server error, check logs'
+            else
+                raise "Unexpected error code: #{rc}"
+            end
+        end
+    when 500
+        raise 'Server error, check logs'
+    else
+        raise "Unexpected error code: #{rc}"
+    end
+end
+
+def verify_service_delete(sr_id)
+    attempts = @conf[:conf][:timeouts][:delete]
+    1.upto(attempts) do |t|
+        expect(t <= attempts).to be(true)
+        sleep 1
+
+        response = @conf[:client][:oneflow].get("/service/#{sr_id}")
+        rc = response.code.to_i
+
+        next if rc == 200
+
+        break
+    end
+end
+
+############################################################################
+# Helpers
+############################################################################
+
+def random_string
+    chars = ('a'..'z').to_a + ('A'..'Z').to_a
+    string = ''
+    8.times { string << chars[SecureRandom.rand(chars.size)] }
+    string
+end
+
+def random_faas_minimal
+    flavour = random_string
+    pp "rolled a random flavour #{flavour}"
+
+    {
+        'SERVERLESS_RUNTIME' => {
+            'NAME' => flavour,
+            'FAAS' => {
+                'FLAVOUR' => flavour
+            },
+            'SCHEDULING' => {},
+            'DEVICE_INFO' => {}
+        }
+    }
+end

--- a/tests/lib/crud.rb
+++ b/tests/lib/crud.rb
@@ -30,11 +30,15 @@ RSpec.shared_context 'crud' do |sr_template|
             runtime = JSON.parse(response.body)
             pp runtime
 
-            # TODO: Check flow service for failed states like 7 => FAILED_DEPLOYING
-            next unless runtime['SERVERLESS_RUNTIME']['FAAS']['STATE'] == 'ACTIVE'
-
-            verify_sr_spec(@conf[:specification], runtime)
-            break
+            case runtime['SERVERLESS_RUNTIME']['FAAS']['STATE']
+            when 'ACTIVE'
+                verify_sr_spec(@conf[:specification], runtime)
+                break
+            when 'FAILED'
+                raise 'FaaS VM failed to deploy'
+            else
+                next
+            end
         end
     end
 

--- a/tests/lib/crud.rb
+++ b/tests/lib/crud.rb
@@ -3,20 +3,14 @@ RSpec.shared_context 'crud' do |sr_template|
         pp "Requesting #{SR} creation with template #{sr_template}"
 
         specification = JSON.load_file("templates/#{sr_template}")
-        response = @conf[:engine_client].create(specification)
+        response = @conf[:client][:engine].create(specification)
+        @conf[:specification] = specification
 
         expect(response.code).to eq(201)
 
         runtime = JSON.parse(response.body)
-        pp runtime
 
         @conf[:id] = runtime['SERVERLESS_RUNTIME']['ID'].to_i
-
-        validation = ProvisionEngine::ServerlessRuntime.validate(runtime)
-        pp validation[1]
-
-        raise validation[1] unless validation[0]
-
         @conf[:create] = true
     end
 
@@ -26,10 +20,10 @@ RSpec.shared_context 'crud' do |sr_template|
         attempts = @conf[:conf][:timeouts][:get]
 
         1.upto(attempts) do |t|
+            expect(t <= attempts).to be(true)
             sleep 1
-            expect(t == attempts).to be(false)
 
-            response = @conf[:engine_client].get(@conf[:id])
+            response = @conf[:client][:engine].get(@conf[:id])
 
             expect(response.code).to eq(200)
 
@@ -39,13 +33,14 @@ RSpec.shared_context 'crud' do |sr_template|
             # TODO: Check flow service for failed states like 7 => FAILED_DEPLOYING
             next unless runtime['SERVERLESS_RUNTIME']['FAAS']['STATE'] == 'ACTIVE'
 
+            verify_sr_spec(@conf[:specification], runtime)
             break
         end
     end
 
     it "fail to update #{SR}" do
         # skip "#{SR} creation failed" unless @conf[:create]
-        response = @conf[:engine_client].update(@conf[:id], {})
+        response = @conf[:client][:engine].update(@conf[:id], {})
 
         expect(response.code).to eq(501)
 
@@ -58,6 +53,6 @@ RSpec.shared_context 'crud' do |sr_template|
     it "delete a #{SR}" do
         skip "#{SR} creation failed" unless @conf[:create]
 
-        wait_delete(@conf[:id])
+        verify_sr_delete(@conf[:id])
     end
 end

--- a/tests/lib/crud_invalid.rb
+++ b/tests/lib/crud_invalid.rb
@@ -1,22 +1,22 @@
 RSpec.shared_context 'crud_invalid' do
     it "fail to create a #{SR} with invalid FLAVOUR" do
-        response = @conf[:engine_client].create(random_faas_minimal)
+        response = @conf[:client][:engine].create(random_faas_minimal)
         expect(response.code).to eq(422)
     end
 
     it "fail to create a #{SR} with invalid schema" do
         specification = {
-            :SERVERLESS_RUNTIME => {
-                :FAAS => {
-                    :FLAVOUR => 'Function'
+            'SERVERLESS_RUNTIME' => {
+                'FAAS' => {
+                    'FLAVOUR' => 'Function'
                 },
-                :DAAS => {}, # DAAS should be null or have properties
-                :SCHEDULING => {},
-                :DEVICE_INFO => {}
+                'DAAS' => {}, # DAAS should be null or have properties
+                'SCHEDULING' => {},
+                'DEVICE_INFO' => {}
             }
         }
 
-        response = @conf[:engine_client].create(specification)
+        response = @conf[:client][:engine].create(specification)
         expect(response.code).to eq(400)
     end
 
@@ -24,18 +24,18 @@ RSpec.shared_context 'crud_invalid' do
         @conf[:invalid] = {}
         @conf[:invalid][:sky] = 2147483647 # biggest ID for a pool element
 
-        response = @conf[:engine_client].get(@conf[:invalid][:sky])
+        response = @conf[:client][:engine].get(@conf[:invalid][:sky])
         expect(response.code).to eq(404)
     end
 
     it "fail to update a non existing #{SR}" do
-        response = @conf[:engine_client].update(@conf[:invalid][:sky], {})
+        response = @conf[:client][:engine].update(@conf[:invalid][:sky], {})
         expect(response.code).to eq(501)
         # expect(response.code).to eq(404)
     end
 
     it "fail to delete a non existing #{SR}" do
-        response = @conf[:engine_client].delete(@conf[:invalid][:sky])
+        response = @conf[:client][:engine].delete(@conf[:invalid][:sky])
         expect(response.code).to eq(404)
     end
 end

--- a/tests/lib/crud_invalid.rb
+++ b/tests/lib/crud_invalid.rb
@@ -1,6 +1,6 @@
 RSpec.shared_context 'crud_invalid' do
     it "fail to create a #{SR} with invalid FLAVOUR" do
-        response = @conf[:client][:engine].create(random_faas_minimal)
+        response = @conf[:client][:engine].create(generate_faas_minimal)
         expect(response.code).to eq(422)
     end
 

--- a/tests/templates/sr_faas_denyVMTemplate.json
+++ b/tests/templates/sr_faas_denyVMTemplate.json
@@ -1,9 +1,0 @@
-{
-  "SERVERLESS_RUNTIME": {
-    "FAAS": {
-      "FLAVOUR": "DenyVMTemplate"
-    },
-    "SCHEDULING": {},
-    "DEVICE_INFO": {}
-  }
-}

--- a/tests/templates/sr_faas_denyVMTemplate.json
+++ b/tests/templates/sr_faas_denyVMTemplate.json
@@ -1,0 +1,9 @@
+{
+  "SERVERLESS_RUNTIME": {
+    "FAAS": {
+      "FLAVOUR": "DenyVMTemplate"
+    },
+    "SCHEDULING": {},
+    "DEVICE_INFO": {}
+  }
+}


### PR DESCRIPTION
Tests 
- SR object from create now gets verified deeper.
  - specification values match resulting SR 
  - specification values from each Function match VM template
  - service gets created
  - service gets deleted
  - fails fast if SR gets FAILED state as a consequence of `VM.state_str` getting FAILED as well
- auth: permission denied to use VM template verification
- More libraries and improved architecture
  - cleaned `init.rb` from shared functionality, now is only rspec configure, dependency management and rspec execution
  - added vanilla oned and oneflow client from OpenNebula to verify correct `ProvisionEngine::CloudClient` results

Fixes
- deletions were returning error **500** when the service was during DEPLOYMENT state
    - now an error **423** is returned to indicate the transient state 
	- now deletion verifications handle 423 and 204 cases 
	- Ideally [oneflow should handle this](https://github.com/OpenNebula/one/blob/652eddb2eb39b3f7da9752bf239fd19123cbc477/src/flow/oneflow-server.rb#L171-L187) instead of the Provision Engine relying on mapping error 500 from oneflow + response body verification containing `Service cannot be undeployed in state: DEPLOYING`.

Infra
- Added **DenyVMTemplate** service template to verify permission denied on VM Template

Closes #19 