### PR TITLE
Improve SR states

### DIFF
--- a/src/server/runtime.rb
+++ b/src/server/runtime.rb
@@ -10,6 +10,39 @@ module ProvisionEngine
 
         DOCUMENT_TYPE = 1337
 
+        FUNCTION_STATES = ['PENDING', 'RUNNING', 'UPDATING', 'ERROR'].freeze
+        FUNCTION_LCM_STATES = {
+            FUNCTION_STATES[0] => [
+                'LCM_INIT',
+                'BOOT',
+                'PROLOG',
+                'BOOT_UNKNOWN',
+                'BOOT_POWEROFF',
+                'BOOT_SUSPENDED',
+                'BOOT_STOPPED',
+                'BOOT_UNDEPLOY',
+                'PROLOG_UNDEPLOY',
+                'CLEANUP_RESUBMIT'
+            ],
+            FUNCTION_STATES[1] => ['RUNNING'],
+            FUNCTION_STATES[3] => [
+                'FAILURE',
+                'UNKNOWN',
+                'BOOT_FAILURE',
+                'BOOT_MIGRATE_FAILURE',
+                'BOOT_UNDEPLOY_FAILURE',
+                'BOOT_STOPPED_FAILURE',
+                'PROLOG_FAILURE',
+                'PROLOG_MIGRATE_FAILURE',
+                'PROLOG_MIGRATE_POWEROFF_FAILURE',
+                'PROLOG_MIGRATE_SUSPEND_FAILURE',
+                'PROLOG_RESUME_FAILURE',
+                'PROLOG_UNDEPLOY_FAILURE',
+                'PROLOG_MIGRATE_UNKNOWN',
+                'PROLOG_MIGRATE_UNKNOWN_FAILURE'
+            ]
+        }.freeze
+
         SCHEMA_SPECIFICATION = {
             :type => 'object',
             :properties => {
@@ -42,6 +75,13 @@ module ProvisionEngine
                         },
                         :FLAVOUR => {
                             :type => 'string'
+                        },
+                        :VM_ID => {
+                            :type => 'integer'
+                        },
+                        :STATE => {
+                            :type =>  'string',
+                            :enum => FUNCTION_STATES
                         }
                     },
                     :required => ['FLAVOUR']
@@ -65,9 +105,16 @@ module ProvisionEngine
                                     },
                                     :FLAVOUR => {
                                         :type => 'string'
+                                    },
+                                    :VM_ID => {
+                                        :type => 'integer'
+                                    },
+                                    :STATE => {
+                                        :type => 'string',
+                                        :enum => FUNCTION_STATES
                                     }
                                 },
-                              :required => ['FLAVOUR']
+                                :required => ['FLAVOUR']
                             },
                             {
                                 :type =>  'null'
@@ -100,39 +147,6 @@ module ProvisionEngine
                 :required => ['FAAS']
                 }
             }
-        }.freeze
-
-        FUNCTION_STATES = ['PENDING', 'RUNNING', 'UPDATING', 'ERROR'].freeze
-        FUNCTION_LCM_STATES = {
-            FUNCTION_STATES[0] => [
-                'LCM_INIT',
-                'BOOT',
-                'PROLOG',
-                'BOOT_UNKNOWN',
-                'BOOT_POWEROFF',
-                'BOOT_SUSPENDED',
-                'BOOT_STOPPED',
-                'BOOT_UNDEPLOY',
-                'PROLOG_UNDEPLOY',
-                'CLEANUP_RESUBMIT'
-            ],
-            FUNCTION_STATES[1] => ['RUNNING'],
-            FUNCTION_STATES[3] => [
-                'FAILURE',
-                'UNKNOWN',
-                'BOOT_FAILURE',
-                'BOOT_MIGRATE_FAILURE',
-                'BOOT_UNDEPLOY_FAILURE',
-                'BOOT_STOPPED_FAILURE',
-                'PROLOG_FAILURE',
-                'PROLOG_MIGRATE_FAILURE',
-                'PROLOG_MIGRATE_POWEROFF_FAILURE',
-                'PROLOG_MIGRATE_SUSPEND_FAILURE',
-                'PROLOG_RESUME_FAILURE',
-                'PROLOG_UNDEPLOY_FAILURE',
-                'PROLOG_MIGRATE_UNKNOWN',
-                'PROLOG_MIGRATE_UNKNOWN_FAILURE'
-            ]
         }.freeze
 
         attr_accessor :cclient, :body

--- a/src/server/runtime.rb
+++ b/src/server/runtime.rb
@@ -48,103 +48,123 @@ module ProvisionEngine
             :properties => {
                 :SERVERLESS_RUNTIME => {
                     :type => 'object',
-                :properties => {
-                    :NAME => {
-                        :type => 'string'
-                    },
-                    :ID => {
-                        :type => 'integer'
-                    },
-                    :SERVICE_ID => {
-                        :type => 'integer'
-                    },
-                    :FAAS => {
-                        :type => 'object',
                     :properties => {
-                        :CPU => {
-                            :type => 'number'
-                        },
-                        :VCPU => {
-                            :type => 'float'
-                        },
-                        :MEMORY => {
-                            :type => 'integer'
-                        },
-                        :DISK_SIZE => {
-                            :type => 'integer'
-                        },
-                        :FLAVOUR => {
+                        :NAME => {
                             :type => 'string'
                         },
-                        :VM_ID => {
+                        :ID => {
                             :type => 'integer'
                         },
-                        :STATE => {
-                            :type =>  'string',
-                            :enum => FUNCTION_STATES
-                        }
-                    },
-                    :required => ['FLAVOUR']
-                    },
-                    :DAAS => {
-                        'oneOf' => [
-                            {
-                                :type => 'object',
-                                :properties => {
-                                    :CPU => {
-                                        :type => 'number'
-                                    },
-                                    :VCPU => {
-                                        :type => 'integer'
-                                    },
-                                    :MEMORY => {
-                                        :type => 'integer'
-                                    },
-                                    :DISK_SIZE => {
-                                        :type => 'integer'
-                                    },
-                                    :FLAVOUR => {
-                                        :type => 'string'
-                                    },
-                                    :VM_ID => {
-                                        :type => 'integer'
-                                    },
-                                    :STATE => {
-                                        :type => 'string',
-                                        :enum => FUNCTION_STATES
-                                    }
+                        :SERVICE_ID => {
+                            :type => 'integer'
+                        },
+                        :FAAS => {
+                            :type => 'object',
+                            :properties => {
+                                :FLAVOUR => {
+                                    :type => 'string'
                                 },
-                                :required => ['FLAVOUR']
+                                :CPU => {
+                                    :type => 'number'
+                                },
+                                :VCPU => {
+                                    :type => 'integer'
+                                },
+                                :MEMORY => {
+                                    :type => 'integer'
+                                },
+                                :DISK_SIZE => {
+                                    :type => 'integer'
+                                },
+                                :VM_ID => {
+                                    :type => 'integer'
+                                },
+                                :STATE => {
+                                    :type =>  'string',
+                                    :enum => FUNCTION_STATES
+                                },
+                                :ENDPOINT => {
+                                    'oneOf' => [
+                                        {
+                                            :type => 'string'
+                                        },
+                                        {
+                                            :type => 'null'
+                                        }
+                                    ]
+                                }
                             },
-                            {
-                                :type =>  'null'
+                            :required => ['FLAVOUR']
+                        },
+                        :DAAS => {
+                            'oneOf' => [
+                                {
+                                    :type => 'object',
+                                    :properties => {
+                                        :FLAVOUR => {
+                                            :type => 'string'
+                                        },
+                                        :CPU => {
+                                            :type => 'number'
+                                        },
+                                        :VCPU => {
+                                            :type => 'integer'
+                                        },
+                                        :MEMORY => {
+                                            :type => 'integer'
+                                        },
+                                        :DISK_SIZE => {
+                                            :type => 'integer'
+                                        },
+                                        :VM_ID => {
+                                            :type => 'integer'
+                                        },
+                                        :STATE => {
+                                            :type => 'string',
+                                            :enum => FUNCTION_STATES
+                                        },
+                                        :ENDPOINT => {
+                                            'oneOf' => [
+                                                {
+                                                    :type => 'string'
+                                                },
+                                                {
+                                                    :type => 'null'
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    :required => ['FLAVOUR']
+                                },
+                                {
+                                    :type =>  'null'
+                                }
+                            ]
+                        },
+                        :SCHEDULING => {
+                            :type => 'object',
+                            :properties => {
+                                :POLICY => {
+                                    :type => 'string'
+                                },
+                                :REQUIREMENTS => {
+                                    :type => 'string'
+                                }
                             }
-                        ]
-                    },
-                    :SCHEDULING => {
-                        :type => 'object',
-                    :properties => {
-                        :POLICY => {
-                            :type => 'string'
                         },
-                        :REQUIREMENTS => {
-                            :type => 'string'
+                        :DEVICE_INFO => {
+                            :type => 'object',
+                            :properties => {
+                                :LATENCY_TO_PE => {
+                                    :type => 'integer'
+                                },
+                                :GEOGRAPHIC_LOCATION => {
+                                    :type => 'string'
+                                }
+                            }
                         }
-                    }
                     },
-                    :DEVICE_INFO => {
-                        :type => 'object',
-                    :properties => {
-                        :LATENCY_TO_PE => {
-                            :type => 'integer'
-                        },
-                        :GEOGRAPHIC_LOCATION => {
-                            :type => 'string'
-                        }
-                    }
-                    }
-                },
-                :required => ['FAAS']
+                    :required => ['FAAS']
                 }
             }
         }.freeze

--- a/tests/lib/crud.rb
+++ b/tests/lib/crud.rb
@@ -31,10 +31,10 @@ RSpec.shared_context 'crud' do |sr_template|
             pp runtime
 
             case runtime['SERVERLESS_RUNTIME']['FAAS']['STATE']
-            when 'ACTIVE'
+            when ProvisionEngine::ServerlessRuntime::FUNCTION_STATES[1]
                 verify_sr_spec(@conf[:specification], runtime)
                 break
-            when 'FAILED'
+            when ProvisionEngine::ServerlessRuntime::FUNCTION_STATES[3]
                 raise 'FaaS VM failed to deploy'
             else
                 next


### PR DESCRIPTION
Now there are 4 states available for a Function
- PENDING
- RUNNING
- UPDATING
- ERROR

Each Function VM state will be mapped into these states using a combination of expected `vm.state_str` and `vm.lcm_state_str`.

Also 
- a minor bump to validate function to put alongside other top level functions.
- SCHEMA was updated since it was missing Function VM_ID and STATE. STATE was added as an enum with the previous 4 states.