### PR TITLE
VM Template scheduling and device info

### DIFF
--- a/share/examples/serverless-runtime.json
+++ b/share/examples/serverless-runtime.json
@@ -16,7 +16,7 @@
       "REQUIREMENTS": "FREECPU > 10"
     },
     "DEVICE_INFO": {
-      "LATENCY_TO_PE": "100",
+      "LATENCY_TO_PE": 100,
       "GEOGRAPHIC_LOCATION": "Madrid"
     }
   }

--- a/tests/templates/sr_faas_capacity.json
+++ b/tests/templates/sr_faas_capacity.json
@@ -8,7 +8,13 @@
       "DISK_SIZE": 420,
       "FLAVOUR": "Function"
     },
-    "SCHEDULING": {},
-    "DEVICE_INFO": {}
+    "SCHEDULING": {
+      "POLICY": "energy",
+      "REQUIREMENTS": "FREECPU > 10"
+    },
+    "DEVICE_INFO": {
+      "LATENCY_TO_PE": 100,
+      "GEOGRAPHIC_LOCATION": "Madrid"
+    }
   }
 }


### PR DESCRIPTION
Closes #27 

Instantiations like these

```json
{
  "SERVERLESS_RUNTIME": {
    "NAME": "Function as a Service",
    "ID": 881,
    "FAAS": {
      "MEMORY": 111,
      "CPU": 0.44,
      "VCPU": 3,
      "DISK_SIZE": 420,
      "FLAVOUR": "Function",
      "VM_ID": 612,
      "STATE": "PENDING",
      "ENDPOINT": null
    },
    "SCHEDULING": {
      "POLICY": "energy",
      "REQUIREMENTS": "FREECPU > 10"
    },
    "DEVICE_INFO": {
      "LATENCY_TO_PE": 100,
      "GEOGRAPHIC_LOCATION": "Madrid"
    },
    "SERVICE_ID": 880
  }
}
 ~/P/C/provisioning-engine   scheduler *$  src/client  ./http_cli.rb post http://localhost:1337/serverless-runtimes ../../tests/templates/sr_faas_minimal.json            4s
{
  "SERVERLESS_RUNTIME": {
    "NAME": "Function_0f020356-d4b9-4fa7-b7c6-5337cbbcafd0",
    "ID": 883,
    "FAAS": {
      "FLAVOUR": "Function",
      "VM_ID": 613,
      "STATE": "PENDING",
      "ENDPOINT": null,
      "CPU": 0.1,
      "VCPU": 0,
      "MEMORY": 128,
      "DISK_SIZE": 200
    },
    "SCHEDULING": {
    },
    "DEVICE_INFO": {
    },
    "SERVICE_ID": 882
  }
}
```

will result in the function VM now having information about DEVICE_INFO and SCHEDULING. 

```
root@provisionengine-test-env:~# onevm show 612 | grep 'USER TEMPLATE' -A 13
USER TEMPLATE
DEVICE_INFO=[
  GEOGRAPHIC_LOCATION="Madrid",
  LATENCY_TO_PE="100" ]
HOT_RESIZE=[
  CPU_HOT_ADD_ENABLED="YES",
  MEMORY_HOT_ADD_ENABLED="YES" ]
LOGO="images/logos/linux.png"
ROLE_NAME="FAAS"
SCHEDULING=[
  POLICY="energy",
  REQUIREMENTS="FREECPU > 10" ]
SERVICE_ID="880"

root@provisionengine-test-env:~# onevm show 613 | grep 'USER TEMPLATE' -A 13
USER TEMPLATE
HOT_RESIZE=[
  CPU_HOT_ADD_ENABLED="YES",
  MEMORY_HOT_ADD_ENABLED="YES" ]
LOGO="images/logos/linux.png"
ROLE_NAME="FAAS"
SERVICE_ID="882"

VIRTUAL MACHINE TEMPLATE
AUTOMATIC_DS_REQUIREMENTS="(\"CLUSTERS/ID\" @> 0)"
AUTOMATIC_NIC_REQUIREMENTS="(\"CLUSTERS/ID\" @> 0)"
AUTOMATIC_REQUIREMENTS="(CLUSTER_ID = 0) & !(PUBLIC_CLOUD = YES) & !(PIN_POLICY = PINNED)"
CONTEXT=[
  DISK_ID="1",
```

If the properties are missing from the specification, or are empty, they will not be present in the VM Template.

Also
- fixed example json with integer type on LATENCY_TO_PE
- added DEVICE_INFO and SCHEDULING to current test templates on `sr_faas_capacity.json`
- lacks testing