### PR TITLE
Handle services in FAILED_DEPLOYING

### DIFF
--- a/share/swagger/api.yaml
+++ b/share/swagger/api.yaml
@@ -1,6 +1,6 @@
 openapi: "3.0.0"
 info:
-  version: "0.9.12"
+  version: "0.9.13"
   title: "Provisioning Engine REST API"
   description: Provides FaaS capabilities by leveraging features from OpenNebula. Allows to manage Serverless Runtime instances based on a group of Functions defined on request.
 

--- a/src/server/client.rb
+++ b/src/server/client.rb
@@ -107,6 +107,13 @@ module ProvisionEngine
             return_http_response(response)
         end
 
+        def service_recover_delete(id)
+            @logger.debug("Forcing service #{id} deletion")
+
+            response = service_action(id, 'recover', { 'delete' => true })
+            return_http_response(response)
+        end
+
         def service_template_get(id)
             response = @client_oneflow.get("/service_template/#{id}")
             return_http_response(response)
@@ -122,6 +129,32 @@ module ProvisionEngine
 
             response = service_template_action(id, 'instantiate', options)
             return_http_response(response)
+        end
+
+        def service_fail?(service)
+            service_state(service) == 7
+        end
+
+        # SERVICE_STATES = [
+        #     'PENDING',
+        #     'DEPLOYING',
+        #     'RUNNING',
+        #     'UNDEPLOYING',
+        #     'WARNING',
+        #     'DONE',
+        #     'FAILED_UNDEPLOYING',
+        #     'FAILED_DEPLOYING',
+        #     'SCALING',
+        #     'FAILED_SCALING',
+        #     'COOLDOWN',
+        #     'DEPLOYING_NETS',
+        #     'UNDEPLOYING_NETS',
+        #     'FAILED_DEPLOYING_NETS',
+        #     'FAILED_UNDEPLOYING_NETS',
+        #     'HOLD'
+        # ]
+        def service_state(service)
+            service['DOCUMENT']['TEMPLATE']['BODY']['state']
         end
 
         private
@@ -146,7 +179,7 @@ module ProvisionEngine
         end
 
         def service_action(id, action, options = {})
-            url = "/service/#{id}/action", body
+            url = "/service/#{id}/action"
 
             flow_element_action(url, action, options)
         end

--- a/src/server/client.rb
+++ b/src/server/client.rb
@@ -5,6 +5,26 @@ module ProvisionEngine
     #
     class CloudClient
 
+        SERVICE_STATES = [
+            'PENDING',
+            'DEPLOYING',
+            'RUNNING',
+            'UNDEPLOYING',
+            'WARNING',
+            'DONE',
+            'FAILED_UNDEPLOYING',
+            'FAILED_DEPLOYING',
+            'SCALING',
+            'FAILED_SCALING',
+            'COOLDOWN',
+            'DEPLOYING_NETS',
+            'UNDEPLOYING_NETS',
+            'FAILED_DEPLOYING_NETS',
+            'FAILED_UNDEPLOYING_NETS',
+            'HOLD'
+        ]
+
+
         def self.map_error_oned(xmlrpc_errno)
             # ESUCCESS        = 0x0000
             # EAUTHENTICATION = 0x0100
@@ -107,10 +127,10 @@ module ProvisionEngine
             return_http_response(response)
         end
 
-        def service_recover_delete(id)
+        def service_recover(id, options = {})
             @logger.debug("Forcing service #{id} deletion")
 
-            response = service_action(id, 'recover', { 'delete' => true })
+            response = service_action(id, 'recover', options)
             return_http_response(response)
         end
 
@@ -132,27 +152,9 @@ module ProvisionEngine
         end
 
         def service_fail?(service)
-            service_state(service) == 7
+            SERVICE_STATES[service_state(service)].include?('FAILED')
         end
 
-        # SERVICE_STATES = [
-        #     'PENDING',
-        #     'DEPLOYING',
-        #     'RUNNING',
-        #     'UNDEPLOYING',
-        #     'WARNING',
-        #     'DONE',
-        #     'FAILED_UNDEPLOYING',
-        #     'FAILED_DEPLOYING',
-        #     'SCALING',
-        #     'FAILED_SCALING',
-        #     'COOLDOWN',
-        #     'DEPLOYING_NETS',
-        #     'UNDEPLOYING_NETS',
-        #     'FAILED_DEPLOYING_NETS',
-        #     'FAILED_UNDEPLOYING_NETS',
-        #     'HOLD'
-        # ]
         def service_state(service)
             service['DOCUMENT']['TEMPLATE']['BODY']['state']
         end

--- a/src/server/runtime.rb
+++ b/src/server/runtime.rb
@@ -501,12 +501,17 @@ module ProvisionEngine
                 service = rb
 
                 if client.service_fail?(service)
-                    service_log = service['DOCUMENT']['TEMPLATE']['BODY']['log']
-                    client.logger.error("#{SR} service #{service_id} entered FAILED state\n#{service}")
+                    error = "#{SR} service #{service_id} entered FAILED state"
+
+                    client.logger.error(error)
+                    client.logger.debug(service)
 
                     response = recover_service(client, service_id, { :delete => true })
 
-                    response[1] = service_log if response[0] == 204
+                    if response[0] == 204
+                        service_log = service['DOCUMENT']['TEMPLATE']['BODY']['log']
+                        response[1] = { 'error' => error, 'message' => service_log }
+                    end
                 end
 
                 return response

--- a/src/server/server.rb
+++ b/src/server/server.rb
@@ -90,8 +90,8 @@ def log_response(level, code, data, message)
     end
 
     settings.logger.info("#{RC}: #{code}")
-    settings.logger.debug("Response Body: #{body}")
     settings.logger.send(level, message)
+    settings.logger.debug("Response Body: #{body}")
 end
 
 ############################################################################
@@ -177,7 +177,7 @@ get '/serverless-runtimes/:id' do
 
     case rc
     when 200
-        log_response('info', rc, rb, SR)
+        log_response('info', rc, rb, "#{SR} retrieved")
         json_response(rc, rb.to_sr)
     when 401
         log_response('error', rc, rb, NO_AUTH)
@@ -189,7 +189,7 @@ get '/serverless-runtimes/:id' do
         log_response('error', rc, rb, SR_NOT_FOUND)
         halt rc, json_response(rc, rb)
     else
-        log_response('error', 500, rb, "Failed to get #{SR}")
+        log_response('error', 500, rb, "Failed to retrieve #{SR}")
         halt 500, json_response(500, rb)
     end
 end

--- a/src/server/server.rb
+++ b/src/server/server.rb
@@ -22,7 +22,7 @@ require 'configuration'
 require 'client'
 require 'runtime'
 
-VERSION = '0.9.12'
+VERSION = '0.9.13'
 
 ############################################################################
 # Define API Helpers

--- a/src/server/server.rb
+++ b/src/server/server.rb
@@ -158,7 +158,7 @@ post '/serverless-runtimes' do
         log_response('error', rc, rb, "Timeout when creating #{SR}")
         halt rc, json_response(rc, rb)
     else
-        log_response('error', rc, rb, "Failed to create #{SR}")
+        log_response('error', 500, rb, "Failed to create #{SR}")
         halt 500, json_response(500, rb)
     end
 end
@@ -189,7 +189,7 @@ get '/serverless-runtimes/:id' do
         log_response('error', rc, rb, SR_NOT_FOUND)
         halt rc, json_response(rc, rb)
     else
-        log_response('error', rc, rb, "Failed to get #{SR}")
+        log_response('error', 500, rb, "Failed to get #{SR}")
         halt 500, json_response(500, rb)
     end
 end
@@ -244,7 +244,7 @@ delete '/serverless-runtimes/:id' do
             log_response('error', rc, rb, NO_DELETE)
             halt rc, json_response(rc, rb)
         else
-            log_response('error', rc, rb, NO_DELETE)
+            log_response('error', 500, rb, NO_DELETE)
             halt 500, json_response(500, rb)
         end
     when 401
@@ -257,7 +257,7 @@ delete '/serverless-runtimes/:id' do
         log_response('error', rc, rb, SR_NOT_FOUND)
         halt rc, json_response(rc, rb)
     else
-        log_response('error', rc, rb, NO_DELETE)
+        log_response('error', 500, rb, NO_DELETE)
         halt 500, json_response(500, rb)
     end
 end

--- a/tests/init.rb
+++ b/tests/init.rb
@@ -67,4 +67,9 @@ RSpec.describe 'Provision Engine API' do
     end
 
     examples?('inspect logs', rspec_conf[:conf])
+
+    # cleanup possible leftover services for the test user ENV['TESTS_AUTH'][0]
+    after(:all) do
+        # TODO: Skip if oneadmin
+    end
 end

--- a/tests/lib/crud_invalid.rb
+++ b/tests/lib/crud_invalid.rb
@@ -10,7 +10,7 @@ RSpec.shared_context 'crud_invalid' do
                 'FAAS' => {
                     'FLAVOUR' => 'Function'
                 },
-                'DAAS' => {}, # DAAS should be null or have properties
+                'DAAS' => {}, # DAAS should not exist or have FLAVOUR at least
                 'SCHEDULING' => {},
                 'DEVICE_INFO' => {}
             }

--- a/tests/lib/crud_invalid.rb
+++ b/tests/lib/crud_invalid.rb
@@ -20,6 +20,29 @@ RSpec.shared_context 'crud_invalid' do
         expect(response.code).to eq(400)
     end
 
+    # requires a flow template FAILED_DEPLOY which guarantees service on FAILED_DEPLOY
+    it "fail to create #{SR} if oneflow service enters FAIL_DEPLOY" do
+        specification = {
+            'SERVERLESS_RUNTIME' => {
+                'FAAS' => {
+                    'FLAVOUR' => 'FAILED_DEPLOY'
+                },
+                'SCHEDULING' => {},
+                'DEVICE_INFO' => {}
+            }
+        }
+
+        response = @conf[:client][:engine].create(specification)
+
+        expect(response.code).to eq(500)
+
+        body = JSON.parse(response.body)
+
+        ['error', 'message'].each do |k|
+            expect(body.key?(k) && !body[k].empty?).to be(true)
+        end
+    end
+
     it "fail to read a non existing #{SR}" do
         @conf[:invalid] = {}
         @conf[:invalid][:sky] = 2147483647 # biggest ID for a pool element


### PR DESCRIPTION
When the flow service backing the SR fails to instantiate now
- there is an automatic `oneflow recover --delete` equivalent REST API Call issued to oneflow
- the SR document will not be created
- the failure will be fast

Response with error 500

```
 ~/P/C/provisioning-engine   flow_fail *$  src/client  ./http_cli.rb post http://localhost:1337/serverless-runtimes ../../tests/templates/sr_faas_FAILED_DEPLOY.json
{
  "error": "Serverless Runtime service 1065 entered FAILED state",
  "message": [
    {
      "timestamp": 1699916942,
      "severity": "I",
      "message": "New state: DEPLOYING_NETS"
    },
    {
      "timestamp": 1699916942,
      "severity": "E",
      "message": "Role FAAS : Instantiate failed for template 7; [one.template.instantiate] Error allocating a new virtual machine template. Cannot get IP/MAC lease from virtual network 1."
    },
    {
      "timestamp": 1699916942,
      "severity": "I",
      "message": "New state: FAILED_DEPLOYING"
    }
  ]
}
```

Logs

```log
 /p/v/l/provision-engine  cat engine.log                                                                                                                                     8s
# Logfile created on 2023-11-13 17:09:00 -0600 by logger.rb/v1.5.3
I, [2023-11-13 17:09:00 #39449]  INFO -- : Initializing Provision Engine component: engine
I, [2023-11-13 17:09:00 #39449]  INFO -- : Using oned at http://localhost:1338/RPC2
I, [2023-11-13 17:09:00 #39449]  INFO -- : Using oneflow at http://localhost:1339
D, [2023-11-13 17:09:01 #39449] DEBUG -- : API Call: POST /serverless-runtimes {"SERVERLESS_RUNTIME":{"FAAS":{"FLAVOUR":"FAILED_DEPLOY"},"SCHEDULING":{},"DEVICE_INFO":{}}}
I, [2023-11-13 17:09:01 #39449]  INFO -- : Received request to Create a Serverless Runtime
I, [2023-11-13 17:09:03 #39449]  INFO -- : Response HTTP Return Code: 500
E, [2023-11-13 17:09:03 #39449] ERROR -- : Failed to create Serverless Runtime
D, [2023-11-13 17:09:03 #39449] DEBUG -- : Response Body: {"error":"Serverless Runtime service 1065 entered FAILED state","message":[{"timestamp":1699916942,"severity":"I","message":"New state: DEPLOYING_NETS"},{"timestamp":1699916942,"severity":"E","message":"Role FAAS : Instantiate failed for template 7; [one.template.instantiate] Error allocating a new virtual machine template. Cannot get IP/MAC lease from virtual network 1."},{"timestamp":1699916942,"severity":"I","message":"New state: FAILED_DEPLOYING"}]}
D, [2023-11-13 17:10:49 #39449] DEBUG -- : API Call: POST /serverless-runtimes {"SERVERLESS_RUNTIME":{"FAAS":{"FLAVOUR":"Function"},"SCHEDULING":{},"DEVICE_INFO":{}}}
I, [2023-11-13 17:10:49 #39449]  INFO -- : Received request to Create a Serverless Runtime
I, [2023-11-13 17:10:53 #39449]  INFO -- : Response HTTP Return Code: 201
I, [2023-11-13 17:10:53 #39449]  INFO -- : Serverless Runtime created
D, [2023-11-13 17:10:53 #39449] DEBUG -- : Response Body: {
  "DOCUMENT": {
    "ID": "1067",
    "UID": "0",
    "GID": "0",
    "UNAME": "oneadmin",
    "GNAME": "oneadmin",
    "NAME": "Function_bf26ed7a-001e-4239-bccb-525e2960770c",
    "TYPE": "1337",
    "PERMISSIONS": {
      "OWNER_U": "1",
      "OWNER_M": "1",
      "OWNER_A": "0",
      "GROUP_U": "0",
      "GROUP_M": "0",
      "GROUP_A": "0",
      "OTHER_U": "0",
      "OTHER_M": "0",
      "OTHER_A": "0"
    },
    "TEMPLATE": {
      "BODY": {
        "FAAS": {
          "FLAVOUR": "Function",
          "VM_ID": 715,
          "STATE": "PENDING",
          "ENDPOINT": null,
          "CPU": 0.1,
          "VCPU": 0,
          "MEMORY": 128,
          "DISK_SIZE": 200
        },
        "SCHEDULING": {
        },
        "DEVICE_INFO": {
        },
        "SERVICE_ID": 1066,
        "registration_time": 1699917052
      }
    }
  }
}
 /p/v/l/provision-engine  cat CloudClient.log
# Logfile created on 2023-11-13 17:10:49 -0600 by logger.rb/v1.5.3
I, [2023-11-13 17:10:49 #39449]  INFO -- : Initializing Provision Engine component: CloudClient
I, [2023-11-13 17:10:49 #39449]  INFO -- : Creating oneflow Service for Serverless Runtime
I, [2023-11-13 17:10:50 #39449]  INFO -- : Requesting Custom VM Requirements for function FAAS
{"FLAVOUR"=>"Function"}
D, [2023-11-13 17:10:50 #39449] DEBUG -- : Applying vm_template_contents to role FAAS
HOT_RESIZE=[CPU_HOT_ADD_ENABLED="YES",
MEMORY_HOT_ADD_ENABLED="YES"]
MEMORY_RESIZE_MODE="BALLOONING"
VCPU_MAX= "4"
MEMORY_MAX="256"
D, [2023-11-13 17:10:50 #39449] DEBUG -- : Instantiating service_template 241 with options {"roles"=>[{"name"=>"FAAS", "vm_template_contents"=>"HOT_RESIZE=[CPU_HOT_ADD_ENABLED=\"YES\",\nMEMORY_HOT_ADD_ENABLED=\"YES\"]\nMEMORY_RESIZE_MODE=\"BALLOONING\"\nVCPU_MAX= \"4\"\nMEMORY_MAX=\"256\"\nSCHEDULING=[]\nDEVICE_INFO=[]\n"}]}
I, [2023-11-13 17:10:51 #39449]  INFO -- : Serverless Runtime Service 1066 created
D, [2023-11-13 17:10:52 #39449] DEBUG -- : {"DOCUMENT"=>{"ID"=>"1066", "UID"=>"0", "GID"=>"0", "UNAME"=>"oneadmin", "GNAME"=>"oneadmin", "NAME"=>"Function", "TYPE"=>"100", "PERMISSIONS"=>{"OWNER_U"=>"1", "OWNER_M"=>"1", "OWNER_A"=>"0", "GROUP_U"=>"0", "GROUP_M"=>"0", "GROUP_A"=>"0", "OTHER_U"=>"0", "OTHER_M"=>"0", "OTHER_A"=>"0"}, "TEMPLATE"=>{"BODY"=>{"name"=>"Function", "deployment"=>"straight", "description"=>"", "roles"=>[{"name"=>"FAAS", "cardinality"=>1, "vm_template"=>5, "shutdown_action"=>"terminate-hard", "elasticity_policies"=>[], "scheduled_policies"=>[], "vm_template_contents"=>"HOT_RESIZE=[CPU_HOT_ADD_ENABLED=\"YES\",\nMEMORY_HOT_ADD_ENABLED=\"YES\"]\nMEMORY_RESIZE_MODE=\"BALLOONING\"\nVCPU_MAX= \"4\"\nMEMORY_MAX=\"256\"\nSCHEDULING=[]\nDEVICE_INFO=[]\n", "state"=>1, "cooldown"=>300, "nodes"=>[{"deploy_id"=>715, "vm_info"=>{"VM"=>{"ID"=>"715", "UID"=>"0", "GID"=>"0", "UNAME"=>"oneadmin", "GNAME"=>"oneadmin", "NAME"=>"FAAS_0_(service_1066)"}}}], "on_hold"=>false, "last_vmname"=>1}], "ready_status_gate"=>false, "automatic_deletion"=>false, "registration_time"=>1696454194, "state"=>1, "start_time"=>1699917051, "log"=>[{"timestamp"=>1699917051, "severity"=>"I", "message"=>"New state: DEPLOYING_NETS"}, {"timestamp"=>1699917051, "severity"=>"I", "message"=>"New state: DEPLOYING"}]}}}}
I, [2023-11-13 17:10:52 #39449]  INFO -- : Allocating Serverless Runtime Document
D, [2023-11-13 17:10:52 #39449] DEBUG -- : {"FAAS"=>{"FLAVOUR"=>"Function", "VM_ID"=>715, "STATE"=>"PENDING", "ENDPOINT"=>nil, "CPU"=>0.1, "VCPU"=>0, "MEMORY"=>128, "DISK_SIZE"=>200}, "SCHEDULING"=>{}, "DEVICE_INFO"=>{}, "SERVICE_ID"=>1066}
I, [2023-11-13 17:10:53 #39449]  INFO -- : Created Serverless Runtime Document
```

Still missing tests
