### PR TITLE
IPv6 support and tests improvements

### DIFF
--- a/share/api.yaml
+++ b/share/api.yaml
@@ -1,6 +1,6 @@
 openapi: "3.0.0"
 info:
-  version: "0.10.0"
+  version: "0.10.1"
   title: "Provisioning Engine REST API"
   description: Provides FaaS capabilities by leveraging features from OpenNebula. Allows to manage Serverless Runtime instances based on a group of Functions defined on request.
 
@@ -28,7 +28,7 @@ paths:
         security: []
         responses:
           '200':
-            description: Serverless Runtime schema retrieved
+            description: Returns the serverless runtime schema
   /serverless-runtimes:
     post:
       summary: Create a Serverless Runtime
@@ -206,7 +206,7 @@ paths:
                 schema:
                   type: string
                 example:
-                  "0.10.0"
+                  "0.10.1"
   /server/config:
       get:
         summary: Retrieve the Provisioning Engine configuration

--- a/src/server/client.rb
+++ b/src/server/client.rb
@@ -87,7 +87,13 @@ module ProvisionEngine
         end
 
         def service_destroy(id)
-            service_recover(id, { 'delete' => true })
+            response = service_recover(id, { 'delete' => true })
+            return response if response[0] == 204
+
+            # attempt a second recover
+            @logger.error response[1]
+            sleep 1
+            return service_recover(id, { 'delete' => true })
         end
 
         def service_recover(id, options = {})

--- a/src/server/client.rb
+++ b/src/server/client.rb
@@ -109,6 +109,11 @@ module ProvisionEngine
             service['DOCUMENT']['TEMPLATE']['BODY']['state']
         end
 
+        def service_pool_get
+            response = @client_oneflow.get('/service')
+            return_http_response(response)
+        end
+
         def service_template_get(id)
             response = @client_oneflow.get("/service_template/#{id}")
             return_http_response(response)

--- a/src/server/log.rb
+++ b/src/server/log.rb
@@ -16,7 +16,7 @@ module ProvisionEngine
                 :error => :err, :warning => :warning, :info => :info, :debug => :debug
             }
         }
-        SEP = '-----------------------'
+        SEP = '-'*32
 
         #
         # @param [Hash] config Log configuration as defined in engine.conf

--- a/src/server/runtime.rb
+++ b/src/server/runtime.rb
@@ -493,11 +493,15 @@ module ProvisionEngine
                 end
             end
 
-            if vm["#{nic}EXTERNAL_IP"]
-                xaas_template['ENDPOINT'] = vm["#{nic}EXTERNAL_IP"]
-            else
-                xaas_template['ENDPOINT'] = vm["#{nic}IP"]
+            if nic
+                ['EXTERNAL_IP', 'IP6', 'IP'].each do |address| # Priority order
+                    if vm["#{nic}#{address}"]
+                        xaas_template['ENDPOINT'] = vm["#{nic}#{address}"]
+                        break
+                    end
+                end
             end
+            # No ENDPOINT will result in empty string
             xaas_template['ENDPOINT'] = '' unless xaas_template['ENDPOINT']
 
             xaas_template['CPU'] = vm["#{t}VCPU"].to_i

--- a/src/server/runtime.rb
+++ b/src/server/runtime.rb
@@ -140,7 +140,7 @@ module ProvisionEngine
 
             @cclient.logger.warning(SRS_NOT_FOUND) if rc == 404
 
-            if rc != 204
+            if ![204, 404].include?(rc)
                 error = "#{SERVICE_NO_DELETE} #{service_id}"
                 message = response[1]
 

--- a/src/server/runtime.rb
+++ b/src/server/runtime.rb
@@ -59,8 +59,6 @@ module ProvisionEngine
             response = ServerlessRuntime.to_service(client, specification)
             return response unless response[0] == 200
 
-            client.logger.debug_dev(response)
-
             service_id = response[1]['DOCUMENT']['ID'].to_i
             specification['SERVICE_ID'] = service_id
 

--- a/src/server/runtime.rb
+++ b/src/server/runtime.rb
@@ -484,8 +484,7 @@ module ProvisionEngine
             xaas_template['VM_ID'] = vm_id
             xaas_template['STATE'] = map_vm_state(vm)
 
-            if xaas_template['STATE'] == FUNCTION_STATES[3] # error
-                # TODO: Test
+            if xaas_template['STATE'] == 'ERROR'
                 if vm["#{t}ERROR"]
                     xaas_template['ERROR'] = vm["#{t}ERROR"]
                 else

--- a/src/server/server.rb
+++ b/src/server/server.rb
@@ -126,8 +126,9 @@ before do
     end
 end
 
+# TODO: Test
 get '/serverless-runtimes/schema' do
-    json_response(200, ProvisionEngine::ServerlessRuntime::SCHEMA_SPECIFICATION)
+    json_response(200, ProvisionEngine::ServerlessRuntime::SCHEMA)
 end
 
 post '/serverless-runtimes' do
@@ -266,14 +267,12 @@ delete '/serverless-runtimes/:id' do
     end
 end
 
-get '/engine/version' do
-    json_response(200, VERSION)
-end
-
+# TODO: Test
 get '/server/version' do
     json_response(200, VERSION)
 end
 
+# TODO: Test
 get '/server/config' do
     json_response(200, conf)
 end

--- a/src/server/server.rb
+++ b/src/server/server.rb
@@ -126,7 +126,6 @@ before do
     end
 end
 
-# TODO: Test
 get '/serverless-runtimes/schema' do
     json_response(200, ProvisionEngine::ServerlessRuntime::SCHEMA)
 end
@@ -267,12 +266,10 @@ delete '/serverless-runtimes/:id' do
     end
 end
 
-# TODO: Test
 get '/server/version' do
     json_response(200, VERSION)
 end
 
-# TODO: Test
 get '/server/config' do
     json_response(200, conf)
 end

--- a/src/server/server.rb
+++ b/src/server/server.rb
@@ -24,7 +24,7 @@ require 'client'
 require 'error'
 require 'runtime'
 
-VERSION = '0.10.0'
+VERSION = '0.10.1'
 
 ############################################################################
 # Define API Helpers

--- a/tests/conf.yaml
+++ b/tests/conf.yaml
@@ -1,10 +1,10 @@
-# How long to wait for the operation expected result before raising timeout error
-:timeouts:
+:timeouts: # How long to wait for the operation expected result before raising timeout error
   :get: 60
   :delete: 30
-# What group of examples should be tested
-:examples:
-  'auth': true
+:examples: # What group of examples should be tested
   'crud': true
+  'auth': true
   'crud_invalid': true
-  'inspect logs': true
+  'server_info': true
+  'logs': true
+:purge: true # delete services owned by the user running the tests. DO NOT RUN AS ONEADMIN !!!

--- a/tests/init.rb
+++ b/tests/init.rb
@@ -15,16 +15,13 @@ require 'opennebula'
 require 'opennebula/oneflow_client'
 
 # Engine libraries
+$LOAD_PATH << "#{__dir__}/../src/server"
+require 'runtime'
+require 'error'
 require_relative '../src/client/client'
-require_relative '../src/server/runtime'
-require_relative '../src/server/error'
 
 $LOAD_PATH << "#{__dir__}/lib" # Test libraries
 require 'common'
-require 'log'
-require 'crud'
-require 'auth'
-require 'crud_invalid'
 
 ############################################################################
 # Initialize rspec configuration
@@ -39,7 +36,10 @@ flow_client_args = {
 }
 
 rspec_conf = {
-    :conf => YAML.load_file('./conf.yaml'),
+    :conf => {
+        :tests => YAML.load_file('./conf.yaml'),
+        :engine => conf_engine
+    },
     :client => {
         :engine => ProvisionEngine::Client.new(endpoint, auth),
         :oned => OpenNebula::Client.new(auth, conf_engine[:one_xmlrpc]),
@@ -55,21 +55,28 @@ RSpec.configure {|c| c.before { @conf = rspec_conf } }
 ############################################################################
 RSpec.describe 'Provision Engine API' do
     include Rack::Test::Methods
+    tests = rspec_conf[:conf][:tests][:examples]
 
-    examples?('auth', rspec_conf[:conf])
-    examples?('crud_invalid', rspec_conf[:conf])
+    if tests['crud']
+        require 'crud'
 
-    # test every serverless runtime template under templates directory
-    Dir.entries("#{__dir__}/templates").select do |sr_template|
-        # blacklist template from tests by changing preffix or suffix
-        next unless sr_template.start_with?('sr_') && sr_template.end_with?('.json')
+        # test every serverless runtime template under templates directory
+        Dir.entries("#{__dir__}/templates").select do |sr_template|
+            # blacklist template from tests by changing preffix or suffix
+            next unless sr_template.start_with?('sr_') && sr_template.end_with?('.json')
 
-        examples?('crud', rspec_conf[:conf], sr_template)
+            include_context('crud', sr_template)
+        end
     end
 
-    examples?('inspect logs', rspec_conf[:conf])
+    tests.each do |examples, enabled|
+        next if examples == 'crud'
 
-    # cleanup possible leftover services for the test user ENV['TESTS_AUTH'][0]
+        if enabled
+            require examples
+            include_context(examples)
+        end
+    end
     after(:all) do
         # TODO: Skip if oneadmin
     end

--- a/tests/lib/common.rb
+++ b/tests/lib/common.rb
@@ -4,7 +4,7 @@ SR = 'Serverless Runtime'.freeze
 # RSpec methods
 ############################################################################
 
-def examples?(examples, conf, params = nil)
+def load_examples(params = nil)
     include_context(examples, params) if conf[:examples][examples]
 end
 
@@ -84,7 +84,7 @@ def verify_sr_delete(sr_id)
     when 204
         verify_service_delete(sr_id)
     when 423
-        attempts = @conf[:conf][:timeouts][:get]
+        attempts = @conf[:conf][:tests][:timeouts][:get]
         1.upto(attempts) do |t|
             expect(t <= attempts).to be(true)
             sleep 1
@@ -111,7 +111,7 @@ def verify_sr_delete(sr_id)
 end
 
 def verify_service_delete(sr_id)
-    attempts = @conf[:conf][:timeouts][:delete]
+    attempts = @conf[:conf][:tests][:timeouts][:delete]
     1.upto(attempts) do |t|
         expect(t <= attempts).to be(true)
         sleep 1

--- a/tests/lib/common.rb
+++ b/tests/lib/common.rb
@@ -69,7 +69,11 @@ def verify_sr_spec(specification, runtime)
         if specification[role]['DISK_SIZE']
             expect(vm["#{t}DISK[DISK_ID=\"0\"]/SIZE"].to_i).to eq(specification[role]['DISK_SIZE'])
         end
-        # rubocop:enable Style/StringLiterals
+
+        if vm["#{t}ERROR"]
+            expect(runtime[role]['STATE']).to eq('ERROR')
+            expect(runtime[role]['ERROR']).to eq(vm["#{t}ERROR"])
+        end
     end
 end
 

--- a/tests/lib/common.rb
+++ b/tests/lib/common.rb
@@ -30,11 +30,15 @@ def verify_sr_spec(specification, runtime)
     response = @conf[:client][:oneflow].get("/service/#{runtime['SERVICE_ID']}")
     expect(response.code.to_i).to eq(200)
 
+    t = '//TEMPLATE/'
+
     ['FAAS', 'DAAS'].each do |role|
         next unless specification[role] && !specification[role]['FLAVOUR'].empty?
 
         vm = OpenNebula::VirtualMachine.new_with_id(runtime[role]['VM_ID'], @conf[:client][:oned])
         raise "Error getting #{SR} VM" if OpenNebula.is_error?(vm.info)
+
+        nic = "#{t}NIC[NIC_ID=\"0\"]/"
 
         # mandatory role information exists
         ['FLAVOUR', 'VM_ID', 'STATE', 'ENDPOINT'].each do |mandatory|
@@ -48,18 +52,22 @@ def verify_sr_spec(specification, runtime)
             expect(runtime[role][optional]).to eq(specification[role][optional])
         end
 
-        # rubocop:disable Style/StringLiterals
         # verify VM has correct resources
         ['CPU', 'VCPU', 'MEMORY'].each do |capacity|
             next unless specification[role][capacity]
 
-            expect(vm["//TEMPLATE/#{capacity}"].to_f).to eq(specification[role][capacity].to_f)
+            expect(vm["#{t}#{capacity}"].to_f).to eq(specification[role][capacity].to_f)
         end
 
-        expect(runtime[role]['ENDPOINT']).to eq(vm["//TEMPLATE/NIC[NIC_ID=\"0\"]/IP"].to_s)
+        ['EXTERNAL_IP', 'IP6', 'IP'].each do |address|
+            if vm["#{nic}#{address}"]
+                expect(runtime[role]['ENDPOINT']).to eq(vm["#{nic}#{address}"])
+                break
+            end
+        end
 
         if specification[role]['DISK_SIZE']
-            expect(vm["//TEMPLATE/DISK[DISK_ID=\"0\"]/SIZE"].to_i).to eq(specification[role]['DISK_SIZE'])
+            expect(vm["#{t}DISK[DISK_ID=\"0\"]/SIZE"].to_i).to eq(specification[role]['DISK_SIZE'])
         end
         # rubocop:enable Style/StringLiterals
     end

--- a/tests/lib/crud.rb
+++ b/tests/lib/crud.rb
@@ -17,29 +17,12 @@ RSpec.shared_context 'crud' do |sr_template|
     it "read a #{SR}" do
         skip "#{SR} creation failed" unless @conf[:create]
 
-        attempts = @conf[:conf][:timeouts][:get]
+        response = @conf[:client][:engine].get(@conf[:id])
+        expect(response.code).to eq(200)
 
-        1.upto(attempts) do |t|
-            expect(t <= attempts).to be(true)
-            sleep 1
+        runtime = JSON.parse(response.body)
 
-            response = @conf[:client][:engine].get(@conf[:id])
-
-            expect(response.code).to eq(200)
-
-            runtime = JSON.parse(response.body)
-            pp runtime
-
-            case runtime['SERVERLESS_RUNTIME']['FAAS']['STATE']
-            when ProvisionEngine::ServerlessRuntime::FUNCTION_STATES[1]
-                verify_sr_spec(@conf[:specification], runtime)
-                break
-            when ProvisionEngine::ServerlessRuntime::FUNCTION_STATES[3]
-                raise 'FaaS VM failed to deploy'
-            else
-                next
-            end
-        end
+        verify_sr_spec(@conf[:specification], runtime)
     end
 
     it "fail to update #{SR}" do

--- a/tests/lib/logs.rb
+++ b/tests/lib/logs.rb
@@ -1,4 +1,4 @@
-RSpec.shared_context 'inspect logs' do
+RSpec.shared_context 'logs' do
     it 'print every log' do
         logcation = '/var/log/provision-engine'
         sep = '-'*32

--- a/tests/lib/server_info.rb
+++ b/tests/lib/server_info.rb
@@ -1,0 +1,37 @@
+RSpec.shared_context 'server_info' do
+    it 'engine version can be queried through API' do
+        response = Net::HTTP.get_response(URI("#{@conf[:endpoint]}/server/version"))
+        expect(response.code).to eq('200')
+
+        body = JSON.parse(response.body)
+        expect(valid_semantic_version?(body)).to be(true)
+    end
+
+    it '/etc/provision-engine/engine.conf matches loaded config' do
+        response = Net::HTTP.get_response(URI("#{@conf[:endpoint]}/server/config"))
+        expect(response.code).to eq('200')
+
+        body = JSON.parse(response.body)
+        expect(deep_symbolize_keys(body) == @conf[:conf][:engine]).to be(true)
+    end
+
+    it '/etc/provision-engine/schemas/serverless_runtime.json matches current branch schema' do
+        response = Net::HTTP.get_response(URI("#{@conf[:endpoint]}/serverless-runtimes/schema"))
+        expect(response.code).to eq('200')
+
+        body = JSON.parse(response.body)
+        expect(body == ProvisionEngine::ServerlessRuntime::SCHEMA).to be(true)
+    end
+end
+
+def valid_semantic_version?(version)
+    version.match?(/\A\d+\.\d+\.\d+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?\z/)
+end
+
+def deep_symbolize_keys(hash)
+    hash.each_with_object({}) do |(key, value), result|
+        new_key = key.to_sym
+        new_value = value.is_a?(Hash) ? deep_symbolize_keys(value) : value
+        result[new_key] = new_value
+    end
+end


### PR DESCRIPTION
Functionality
-------------

- ENDPOINT selection is now based on the following priority `['EXTERNAL_IP', 'IP6', 'IP']`
	- if none of those parameters are found the endpoint will be an empty string as noted in the schema
- Removed a server info call

Tests
-----

- Added tests for server info calls
- Added optional automatic service cleanup enabled by default
```
."Found leftover services as the user github_actions"
"795: FAILED_DEPLOY"
"793: Function"
```
  - In case of errors any service readable by the user running the tests will be deleted
  - on the cognit infra the test user is `github_actions` with extremely limited access
  - if tests are run as `oneadmin` then every service would be deleted. This is useful when running on dev envs
- Added tests to verify ERROR in Functions