### PR TITLE
Set reschedule flag on update

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 install() {
 	# dependencies
 	for gem in "${gems[@]}"; do
-		is_gem_installed "$gem" || sudo gem install "$gem"
+		is_gem_installed $gem || sudo gem install $gem
 	done
 
 	[ -d "$CONF_DIR" ] || sudo mkdir "$CONF_DIR"
@@ -87,7 +87,7 @@ EXEC_PATH="/usr/local/bin/${EXEC_FILE}"
 INSTALL_DIR="/opt/provision-engine"
 MODULES="client.rb configuration.rb log.rb server.rb runtime.rb error.rb function.rb"
 
-gems=("opennebula" "sinatra" "logger" "json-schema") # check requires on server.rb
+gems=("opennebula" "sinatra -v 3.1.0" "logger -v 1.6.0" "json-schema -v 4.1.1") # check requires on server.rb
 
 action="${1:-"install"}"
 setup_mode="${2:-"symlink"}"

--- a/share/api.yaml
+++ b/share/api.yaml
@@ -1,6 +1,6 @@
 openapi: "3.0.0"
 info:
-  version: "1.0.0"
+  version: "1.1.0"
   title: "Provisioning Engine REST API"
   description: Provides FaaS capabilities by leveraging features from OpenNebula. Allows to manage Serverless Runtime instances based on a group of Functions defined on request.
 

--- a/src/server/function.rb
+++ b/src/server/function.rb
@@ -42,6 +42,10 @@ module ProvisionEngine
                 'PROLOG_MIGRATE_UNKNOWN_FAILURE'
             ]
         }.freeze
+        SCHED_MAP = {
+            'REQUIREMENTS' => 'SCHED_REQUIREMENTS',
+            'POLICY' => 'SCHED_RANK'
+        }
         FUNCTIONS = ['FAAS', 'DAAS'].freeze
 
         T = '//TEMPLATE/'.freeze
@@ -309,6 +313,40 @@ module ProvisionEngine
             end
 
             return STATES[:updating]
+        end
+
+        #
+        # Translates specification parameters to Function VM USER_TEMPLATE
+        #
+        # @param [Hash] specification Serverless Runtime definition
+        #
+        # @return [String] User Template string compatible with opennebula VM Template
+        #
+        def self.map_user_template(specification)
+            schevice=''
+
+            if specification.key?('SCHEDULING')
+                specification['SCHEDULING'].each do |property, value|
+                    schevice << "#{Function::SCHED_MAP[property]}=\"#{value}\"\n" if value
+                end
+            end
+
+            if specification.key?('DEVICE_INFO')
+                i_template = ''
+
+                specification['DEVICE_INFO'].each do |property, value|
+                    i_template << "#{property}=\"#{value}\",\n" if value
+                end
+
+                if !i_template.empty?
+                    i_template.reverse!.sub!("\n", '').reverse!
+                    i_template.reverse!.sub!(',', '').reverse!
+                end
+
+                schevice << "DEVICE_INFO=[#{i_template}]\n"
+            end
+
+            schevice
         end
 
     end

--- a/src/server/function.rb
+++ b/src/server/function.rb
@@ -45,6 +45,7 @@ module ProvisionEngine
         FUNCTIONS = ['FAAS', 'DAAS'].freeze
 
         T = '//TEMPLATE/'.freeze
+        UT = '//USER_TEMPLATE/'.freeze
         NIC = "#{T}NIC[NIC_ID=\"0\"]".freeze
         SRF = 'Serverless Runtime Function VM'.freeze
 
@@ -56,7 +57,7 @@ module ProvisionEngine
             {
                 :memory => self["#{T}/MEMORY"].to_i,
                 :resize => {
-                    :enabled => self['//USER_TEMPLATE/MEMORY_HOT_ADD_ENABLED'],
+                    :enabled => self["#{UT}MEMORY_HOT_ADD_ENABLED"],
                     :mode => self["#{T}/MEMORY_RESIZE_MODE"],
                     :limit => self["#{T}/MEMORY_MAX"].to_i
                 }
@@ -69,7 +70,7 @@ module ProvisionEngine
                 :cpu => self["#{T}/CPU"].to_f,
                 :vcpu => self["#{T}/VCPU"].to_i,
                 :resize => {
-                    :enabled => self['//USER_TEMPLATE/CPU_HOT_ADD_ENABLED'],
+                    :enabled => self["#{UT}CPU_HOT_ADD_ENABLED"],
                     :limit => self["#{T}/VCPU_MAX"].to_i
                 }
             }
@@ -81,6 +82,14 @@ module ProvisionEngine
 
         def error
             self["#{T}ERROR"]
+        end
+
+        def report_ready?
+            self["#{T}/CONTEXT/REPORT_READY"] == 'YES'
+        end
+
+        def ready?
+            self["#{UT}READY"] == 'YES'
         end
 
         #
@@ -199,7 +208,7 @@ module ProvisionEngine
         end
 
         #
-        # CPU and Memory capacity resize operations for the Serverless Runtime Function as a Service Virtual Machine
+        # CPU and Memory capacity resize operations for the Serverless Runtime Function
         #
         # @param [Hash] specification Desired VM state with capactiy changes
         #
@@ -279,12 +288,23 @@ module ProvisionEngine
         end
 
         #
-        # Maps an OpenNebula VM state to the accepted Function VM states
+        # Maps an OpenNebula VM state to the accepted Function VM states.
+        # When the Function VM instance contains CONTEXT/REPORT_READY=YES
+        # The RUNNING state for the Function will need to meet both hypervisor RUNNING
+        # and onegate READY verification.
         #
         # @return [String] Serverless Runtime Function state
         #
         def state_function
             STATE_MAP.each do |function_state, lcm_states|
+                if lcm_state_str == 'RUNNING'
+                    return STATES[:running] unless report_ready?
+
+                    return STATES[:running] if ready?
+
+                    return STATES[:pending]
+                end
+
                 return function_state if lcm_states.include?(lcm_state_str)
             end
 

--- a/src/server/runtime.rb
+++ b/src/server/runtime.rb
@@ -212,25 +212,7 @@ module ProvisionEngine
 
                 end
 
-                schevice=''
-
-                # update user template on each Function VM with client info and requirements
-                ['SCHEDULING', 'DEVICE_INFO'].each do |i|
-                    next unless specification.key?(i)
-                    next if @body[i] == specification[i]
-
-                    i_template = ''
-                    specification[i].each do |property, value|
-                        i_template << "#{property}=\"#{value}\",\n" if value
-                    end
-
-                    if !i_template.empty?
-                        i_template.reverse!.sub!("\n", '').reverse!
-                        i_template.reverse!.sub!(',', '').reverse!
-                    end
-
-                    schevice << "#{i}=[#{i_template}]\n"
-                end
+                schevice = Function.map_user_template(specification)
 
                 response = vm.update(schevice, true) unless schevice.empty?
 
@@ -411,23 +393,7 @@ module ProvisionEngine
                 merge_template = {
                     'roles' => []
                 }
-                schevice=''
-
-                ['SCHEDULING', 'DEVICE_INFO'].each do |i|
-                    next unless specification.key?(i)
-
-                    i_template = ''
-                    specification[i].each do |property, value|
-                        i_template << "#{property}=\"#{value}\",\n" if value
-                    end
-
-                    if !i_template.empty?
-                        i_template.reverse!.sub!("\n", '').reverse!
-                        i_template.reverse!.sub!(',', '').reverse!
-                    end
-
-                    schevice << "#{i}=[#{i_template}]\n"
-                end
+                schevice = Function.map_user_template(specification)
 
                 ProvisionEngine::Function::FUNCTIONS.each do |role|
                     next unless specification[role] && !specification[role]['FLAVOUR'].empty?

--- a/src/server/runtime.rb
+++ b/src/server/runtime.rb
@@ -229,6 +229,8 @@ module ProvisionEngine
                     error = "Failed to update #{SRF} #{schevice}"
                     return ProvisionEngine::Error.new(rc, error, response.message)
                 end
+
+                vm.resched # Just the flag. Responsability lies on scheduler
             end
 
             update

--- a/src/server/server.rb
+++ b/src/server/server.rb
@@ -29,7 +29,7 @@ require 'function'
 # API configuration
 ############################################################################
 
-VERSION = '1.0.1'
+VERSION = '1.1.0'
 conf = ProvisionEngine::Configuration.new
 
 configure do

--- a/tests/lib/common.rb
+++ b/tests/lib/common.rb
@@ -31,11 +31,11 @@ def verify_sr_spec(specification, runtime)
     # Verify runtime infomation #
     #############################
 
-    expect(runtime['NAME']).to eq(specification['NAME']) if specification['NAME']
-    expect(runtime.key?('SERVICE_ID')).to be(true)
-
     response = @conf[:client][:oneflow].get("/service/#{runtime['SERVICE_ID']}")
     expect(response.code.to_i).to eq(200) # service has been created
+
+    expect(runtime.key?('SERVICE_ID')).to be(true)
+    expect(runtime['NAME']).to eq(specification['NAME']) if specification['NAME']
 
     ##############################
     # Verify function information #
@@ -91,8 +91,8 @@ def verify_sr_spec(specification, runtime)
         ['DEVICE_INFO', 'SCHEDULING'].each do |schevice|
             next unless specification[schevice] || specification[schevice].empty?
 
-            specification[schevice].each do |sd|
-                expect(vm["#{UT}#{sd}"]).to eq(sd)
+            specification[schevice].each do |k, v|
+                expect(vm["#{UT}#{schevice}/#{k}"]).to eq(v.to_s)
             end
         end
     end
@@ -210,8 +210,8 @@ def randomize_schevice?(specification)
     ['SCHEDULING', 'DEVICE_INFO'].each do |schevice|
         next if specification[SRR][schevice].nil? || specification[SRR][schevice].empty?
 
-        specification[SRR][schevice].each_key do |k, v|
-            if v.is_a?(Int)
+        specification[SRR][schevice].each do |k, v|
+            if v.is_a?(Integer)
                 specification[SRR][schevice][k] = rand(2147483647)
             else
                 specification[SRR][schevice][k] = SecureRandom.alphanumeric

--- a/tests/lib/common.rb
+++ b/tests/lib/common.rb
@@ -59,7 +59,7 @@ def verify_sr_spec(specification, runtime, resched = false)
         end
 
         # TODO: Improve. Could disappear before check
-        expect(vm['//RESCHED']).to eq(1) if resched
+        expect(vm['//RESCHED'].to_i).to eq(1) if resched
 
         nic = "#{T}NIC[NIC_ID=\"0\"]/"
 

--- a/tests/lib/common.rb
+++ b/tests/lib/common.rb
@@ -89,10 +89,16 @@ def verify_sr_spec(specification, runtime)
         end
 
         ['DEVICE_INFO', 'SCHEDULING'].each do |schevice|
-            next unless specification[schevice] || specification[schevice].empty?
+            next unless specification.key?(schevice)
 
-            specification[schevice].each do |k, v|
-                expect(vm["#{UT}#{schevice}/#{k}"]).to eq(v.to_s)
+            if schevice == 'SCHEDULING'
+                specification[schevice].each do |k, v|
+                    expect(vm["#{UT}#{ProvisionEngine::Function::SCHED_MAP[k]}"]).to eq(v.to_s)
+                end
+            else
+                specification[schevice].each do |k, v|
+                    expect(vm["#{UT}#{schevice}/#{k}"]).to eq(v.to_s)
+                end
             end
         end
     end

--- a/tests/lib/common.rb
+++ b/tests/lib/common.rb
@@ -1,6 +1,7 @@
 SR = 'Serverless Runtime'.freeze
 SRR = 'SERVERLESS_RUNTIME'.freeze
 T = '//TEMPLATE/'.freeze
+UT = '//USER_TEMPLATE/'.freeze
 
 HARDWARE = {
     'CPU' => 1,
@@ -91,7 +92,7 @@ def verify_sr_spec(specification, runtime)
             next unless specification[schevice] || specification[schevice].empty?
 
             specification[schevice].each do |sd|
-                expect(vm['//USER_TEMPLATE/'][sd]).to eq(sd)
+                expect(vm["#{UT}#{sd}"]).to eq(sd)
             end
         end
     end

--- a/tests/lib/common.rb
+++ b/tests/lib/common.rb
@@ -45,7 +45,7 @@ def verify_sr_spec(specification, runtime)
     expect(response.code.to_i).to eq(200) # service has been created
 
     ##############################
-    # Verify funtion information #
+    # Verify function information #
     ##############################
     ProvisionEngine::Function::FUNCTIONS.each do |role|
         next unless specification[role] && !specification[role]['FLAVOUR'].empty?
@@ -199,6 +199,10 @@ def increase_runtime_hardware(specification, mode = 'multiply')
             raise "Invalid #{SR} hardware update mode"
         end
     end
+end
+
+def rename_runtime(specification, name = SecureRandom.alphanumeric)
+    specification[SRR]['NAME'] = name
 end
 
 def strip_consequential_info(specification)

--- a/tests/lib/common.rb
+++ b/tests/lib/common.rb
@@ -16,7 +16,7 @@ def load_examples(params = nil)
     include_context(examples, params) if conf[:examples][examples]
 end
 
-def verify_sr_spec(specification, runtime)
+def verify_sr_spec(specification, runtime, resched = false)
     [specification, runtime].each do |sr|
         response = ProvisionEngine::ServerlessRuntime.validate(sr)
 
@@ -88,6 +88,11 @@ def verify_sr_spec(specification, runtime)
 
         if specification[role]['DISK_SIZE']
             expect(vm["#{T}DISK[DISK_ID=\"0\"]/SIZE"].to_i).to eq(specification[role]['DISK_SIZE'])
+        end
+
+        if resched
+            # Get VM history
+            # verify it got migrated to a different host
         end
 
         if vm["#{T}ERROR"]

--- a/tests/lib/common.rb
+++ b/tests/lib/common.rb
@@ -58,6 +58,9 @@ def verify_sr_spec(specification, runtime, resched = false)
             raise "Error getting #{SR} function VM #{role} \n#{response.message}"
         end
 
+        # TODO: Improve. Could disappear before check
+        expect(vm['//RESCHED']).to eq(1) if resched
+
         nic = "#{T}NIC[NIC_ID=\"0\"]/"
 
         # mandatory role information exists
@@ -88,11 +91,6 @@ def verify_sr_spec(specification, runtime, resched = false)
 
         if specification[role]['DISK_SIZE']
             expect(vm["#{T}DISK[DISK_ID=\"0\"]/SIZE"].to_i).to eq(specification[role]['DISK_SIZE'])
-        end
-
-        if resched
-            # Get VM history
-            # verify it got migrated to a different host
         end
 
         if vm["#{T}ERROR"]
@@ -208,6 +206,20 @@ end
 
 def rename_runtime(specification, name = SecureRandom.alphanumeric)
     specification[SRR]['NAME'] = name
+end
+
+def randomize_schevice?(specification)
+    ['SCHEDULING', 'DEVICE_INFO'].each do |schevice|
+        next if specification[SRR][schevice].nil? || specification[SRR][schevice].empty?
+
+        specification[SRR][schevice].each_key do |k, v|
+            if v.is_a?(Int)
+                specification[SRR][schevice][k] = rand(2147483647)
+            else
+                specification[SRR][schevice][k] = SecureRandom.alphanumeric
+            end
+        end
+    end
 end
 
 def strip_consequential_info(specification)

--- a/tests/lib/crud.rb
+++ b/tests/lib/crud.rb
@@ -50,25 +50,40 @@ RSpec.shared_context 'crud' do |sr_template|
 
             response = @conf[:client][:engine].update(@conf[:id], @conf[:runtime])
             rc = response.code
-            body = JSON.parse(response.body)
+            runtime = JSON.parse(response.body)
 
             case rc
             when 200
-                verify_sr_spec(@conf[:runtime], body)
+                pp runtime
+
+                verify_sr_spec(@conf[:runtime], runtime)
                 break
             when 423
                 pp "Waiting for #{SR} to be RUNNING"
-                verify_error(body)
+                verify_error(runtime)
 
                 sleep 1
                 next
             else
-                pp body
-                verify_error(body)
+                pp runtime
+                verify_error(runtime)
 
                 raise "Unexpected error code #{rc}"
             end
         end
+    end
+
+    it "read an updated #{SR}" do
+        skip "#{SR} creation failed" unless @conf[:create]
+
+        response = @conf[:client][:engine].get(@conf[:id])
+        expect(response.code).to eq(200)
+
+        runtime = JSON.parse(response.body)
+
+        pp runtime
+
+        verify_sr_spec(@conf[:runtime], runtime)
     end
 
     it "delete a #{SR}" do

--- a/tests/lib/crud.rb
+++ b/tests/lib/crud.rb
@@ -53,7 +53,7 @@ RSpec.shared_context 'crud' do |sr_template|
 
             case rc
             when 200
-                verify_sr_spec(@conf[:runtime], body)
+                verify_sr_spec(@conf[:runtime], body, true)
                 break
             when 423
                 pp "Waiting for #{SR} to be RUNNING"

--- a/tests/lib/crud.rb
+++ b/tests/lib/crud.rb
@@ -39,11 +39,12 @@ RSpec.shared_context 'crud' do |sr_template|
         skip "#{SR} creation failed" unless @conf[:create]
 
         increase_runtime_hardware(@conf[:runtime], 'increase')
+        rename_runtime(@conf[:runtime])
 
         timeout = @conf[:conf][:tests][:timeouts][:get]
         1.upto(timeout) do |t|
             if t == timeout
-                raise "Timeut reached for #{SR} deployment"
+                raise "Timeout reached for #{SR} deployment"
             end
 
             response = @conf[:client][:engine].update(@conf[:id], @conf[:runtime])

--- a/tests/lib/crud.rb
+++ b/tests/lib/crud.rb
@@ -40,6 +40,7 @@ RSpec.shared_context 'crud' do |sr_template|
 
         increase_runtime_hardware(@conf[:runtime], 'increase')
         rename_runtime(@conf[:runtime])
+        randomize_schevice?(@conf[:runtime])
 
         timeout = @conf[:conf][:tests][:timeouts][:get]
         1.upto(timeout) do |t|

--- a/tests/lib/crud.rb
+++ b/tests/lib/crud.rb
@@ -54,7 +54,7 @@ RSpec.shared_context 'crud' do |sr_template|
 
             case rc
             when 200
-                verify_sr_spec(@conf[:runtime], body, true)
+                verify_sr_spec(@conf[:runtime], body)
                 break
             when 423
                 pp "Waiting for #{SR} to be RUNNING"

--- a/tests/prepare.rb
+++ b/tests/prepare.rb
@@ -5,7 +5,7 @@ require 'tempfile'
 # How to use
 # ./prepare.rb http://one_host:2633/RPC2 http://one_host:2474 0 1
 
-GEMS = ['rspec', 'rack-test'] # gems required for running the tests
+GEMS = ['rspec -v 3.12.0', 'rack-test -v 2.1.0'] # gems required for running the tests
 CONF_PATH = '/etc/provision-engine/engine.conf'
 
 def install_gems

--- a/tests/templates/_sr_sched.json
+++ b/tests/templates/_sr_sched.json
@@ -1,0 +1,15 @@
+{
+  "SERVERLESS_RUNTIME": {
+    "FAAS": {
+      "FLAVOUR": "Function"
+    },
+    "SCHEDULING": {
+      "POLICY": "energy",
+      "REQUIREMENTS": "FREECPU > 10"
+    },
+    "DEVICE_INFO": {
+      "LATENCY_TO_PE": 100,
+      "GEOGRAPHIC_LOCATION": "Madrid"
+    }
+  }
+}

--- a/tests/templates/sr_faas_capacity.json
+++ b/tests/templates/sr_faas_capacity.json
@@ -6,14 +6,6 @@
       "CPU": 3,
       "DISK_SIZE": 1338,
       "FLAVOUR": "Function"
-    },
-    "SCHEDULING": {
-      "POLICY": "energy",
-      "REQUIREMENTS": "FREECPU > 10"
-    },
-    "DEVICE_INFO": {
-      "LATENCY_TO_PE": 100,
-      "GEOGRAPHIC_LOCATION": "Madrid"
     }
   }
 }

--- a/tests/testenv.sh
+++ b/tests/testenv.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+ee_token=$1
+password=$2
+version=$3
+test_user=$4
+
+if [[ ! -f /usr/bin/oned ]]; then # install minione
+    apt update
+    apt install -y ca-certificates
+    wget 'https://github.com/OpenNebula/minione/releases/latest/download/minione'
+    bash ./minione --enterprise "$ee_token" --password "$password" --yes --force --sunstone-port 9869 --version "$version"
+fi
+
+app_components=$(onemarketapp export "Ttylinux - KVM" -d 1 "ttylinux")
+
+app_template=$( echo "$app_components" | head -n 2 | tail -n 1 | cut -d ':' -f 2)
+app_image=$(echo "$app_components" | tail -n 1 | cut -d ':' -f 2)
+
+
+# create user to run Github Actions tests
+oneuser create "$test_user" "$password"
+# create empty virtual network to force service deployment failure
+echo -e NAME=\"github_actions_no_lease\"\\nVN_MAD=\"bridge\"\\nAR=[TYPE=\"ETHERNET\",SIZE=\"0\"] | onevnet create
+
+# configure oneflow to listen external requests
+
+# - name: Create VM Templates for Github Actions
+#   15 github_a oneadmin Github Actions FAILED_DEPLOY                                                                                                                 11/14 02:15:05
+#    9 github_a oneadmin Github Actions
+
+# - name: Create Service Templates for Github Actions
+#  575 github_a oneadmin FAILED_DEPLOY                                                                                                                                11/14 02:18:12
+#  276 github_a oneadmin DenyVMTemplate                                                                                                                               10/13 22:17:10
+#  199 github_a oneadmin Function-Data                                                                                                                                10/10 22:54:20
+#   63 github_a oneadmin Function
+
+services="Function, Function-Data DenyVMTemplate FAILED_DEPLOY"
+
+for s in $services; do
+    onetemplate clone "$app_template" "$s"
+    onetemplate chown "$s" "$test_user"
+done
+
+# - name: Create Service Templates for Github Actions

--- a/tests/testenv.sh
+++ b/tests/testenv.sh
@@ -29,10 +29,12 @@ echo -e NAME=\"github_actions_no_lease\"\\nVN_MAD=\"bridge\"\\nAR=[TYPE=\"ETHERN
 #   15 github_a oneadmin Github Actions FAILED_DEPLOY                                                                                                                 11/14 02:15:05
 #    9 github_a oneadmin Github Actions
 
+# "shutdown_action": "terminate-hard",
+
 # - name: Create Service Templates for Github Actions
 #  575 github_a oneadmin FAILED_DEPLOY                                                                                                                                11/14 02:18:12
 #  276 github_a oneadmin DenyVMTemplate                                                                                                                               10/13 22:17:10
-#  199 github_a oneadmin Function-Data                                                                                                                                10/10 22:54:20
+#  199 github_a oneadmin Function-Data    # add DAAS role after clone from Function                                                                                                                            10/10 22:54:20
 #   63 github_a oneadmin Function
 
 services="Function, Function-Data DenyVMTemplate FAILED_DEPLOY"


### PR DESCRIPTION
Features
- Whenever an update call occurs, each Function will have the resched flag set.
- A helper to get the function objects that conform a runtime
- Changed how `SERVERLESS_RUNTIME.SCHEDULING` is mapped to `VM.USER_TEMPLATE`.

Tests
- Added renaming verification
- Added resched flag verification
- Improved SCHEDULING and DEVICE_INFO tests