### PR TITLE
Add Function FLAVOURS to VM instances

### DIFF
--- a/share/api.yaml
+++ b/share/api.yaml
@@ -1,6 +1,6 @@
 openapi: "3.0.0"
 info:
-  version: "1.1.0"
+  version: "1.2.0"
   title: "Provisioning Engine REST API"
   description: Provides FaaS capabilities by leveraging features from OpenNebula. Allows to manage Serverless Runtime instances based on a group of Functions defined on request.
 

--- a/src/server/function.rb
+++ b/src/server/function.rb
@@ -327,7 +327,7 @@ module ProvisionEngine
 
             if specification.key?('SCHEDULING')
                 specification['SCHEDULING'].each do |property, value|
-                    schevice << "#{Function::SCHED_MAP[property]}=\"#{value}\"\n" if value
+                    schevice << "#{Function::SCHED_MAP[property]}=\"#{value.upcase}\"\n" if value
                 end
             end
 
@@ -345,6 +345,8 @@ module ProvisionEngine
 
                 schevice << "DEVICE_INFO=[#{i_template}]\n"
             end
+
+            schevice << "FLAVOURS=\"#{ProvisionEngine::ServerlessRuntime.tuple(specification)}\"\n"
 
             schevice
         end

--- a/src/server/server.rb
+++ b/src/server/server.rb
@@ -25,11 +25,12 @@ require 'error'
 require 'runtime'
 require 'function'
 
+VERSION = '1.2.0'
+
 ############################################################################
 # API configuration
 ############################################################################
 
-VERSION = '1.1.0'
 conf = ProvisionEngine::Configuration.new
 
 configure do

--- a/tests/conf.yaml
+++ b/tests/conf.yaml
@@ -3,8 +3,8 @@
   :delete: 30
 :examples: # What group of examples should be tested
   'crud': true
-  'auth': true
-  'crud_invalid': true
-  'server_info': true
-  'logs': true
+  'auth': false
+  'crud_invalid': false
+  'server_info': false
+  'logs': false
 :purge: true # delete services owned by the user running the tests. DO NOT RUN AS ONEADMIN !!!

--- a/tests/lib/common.rb
+++ b/tests/lib/common.rb
@@ -88,18 +88,20 @@ def verify_sr_spec(specification, runtime)
             expect(runtime[role]['ERROR']).to eq(vm["#{T}ERROR"])
         end
 
-        ['DEVICE_INFO', 'SCHEDULING'].each do |schevice|
-            next unless specification.key?(schevice)
+        # Verify VM.USER_TEMPLATE
 
-            if schevice == 'SCHEDULING'
-                specification[schevice].each do |k, v|
-                    expect(vm["#{UT}#{ProvisionEngine::Function::SCHED_MAP[k]}"]).to eq(v.to_s)
-                end
-            else
-                specification[schevice].each do |k, v|
-                    expect(vm["#{UT}#{schevice}/#{k}"]).to eq(v.to_s)
-                end
+        expect(vm["#{UT}FLAVOURS"]).to eq(ProvisionEngine::ServerlessRuntime.tuple(specification))
+
+        if specification.key?('SCHEDULING')
+            specification['SCHEDULING'].each do |k, v|
+                expect(vm["#{UT}#{ProvisionEngine::Function::SCHED_MAP[k]}"]).to eq(v.to_s)
             end
+        end
+
+        next unless specification.key?('DEVICE_INFO')
+
+        specification['DEVICE_INFO'].each do |k, v|
+            expect(vm["#{UT}DEVICE_INFO/#{k}"]).to eq(v.to_s)
         end
     end
 end

--- a/tests/lib/common.rb
+++ b/tests/lib/common.rb
@@ -94,7 +94,7 @@ def verify_sr_spec(specification, runtime)
 
         if specification.key?('SCHEDULING')
             specification['SCHEDULING'].each do |k, v|
-                expect(vm["#{UT}#{ProvisionEngine::Function::SCHED_MAP[k]}"]).to eq(v.to_s)
+                expect(vm["#{UT}#{ProvisionEngine::Function::SCHED_MAP[k]}"]).to eq(v.to_s.upcase)
             end
         end
 

--- a/tests/lib/crud.rb
+++ b/tests/lib/crud.rb
@@ -54,8 +54,6 @@ RSpec.shared_context 'crud' do |sr_template|
 
             case rc
             when 200
-                pp runtime
-
                 verify_sr_spec(@conf[:runtime], runtime)
                 break
             when 423
@@ -65,7 +63,6 @@ RSpec.shared_context 'crud' do |sr_template|
                 sleep 1
                 next
             else
-                pp runtime
                 verify_error(runtime)
 
                 raise "Unexpected error code #{rc}"
@@ -80,8 +77,6 @@ RSpec.shared_context 'crud' do |sr_template|
         expect(response.code).to eq(200)
 
         runtime = JSON.parse(response.body)
-
-        pp runtime
 
         verify_sr_spec(@conf[:runtime], runtime)
     end

--- a/tests/templates/_sr_sched.json
+++ b/tests/templates/_sr_sched.json
@@ -1,15 +1,19 @@
 {
   "SERVERLESS_RUNTIME": {
+    "NAME": "Example Serverless Runtime",
     "FAAS": {
-      "FLAVOUR": "Function"
+      "CPU": 1,
+      "MEMORY": 768,
+      "DISK_SIZE": 3072,
+      "FLAVOUR": "Function",
+      "ENDPOINT": ""
     },
     "SCHEDULING": {
       "POLICY": "energy",
-      "REQUIREMENTS": "FREECPU > 10"
+      "REQUIREMENTS": "energy=50"
     },
     "DEVICE_INFO": {
-      "LATENCY_TO_PE": 100,
-      "GEOGRAPHIC_LOCATION": "Madrid"
+      "GEOGRAPHIC_LOCATION": "{'ip':'193.145.247.253','city':'Arrasate / Mondragón','region':'Basque Country','country':'ES','loc':'43.0644,-2.4898','org':'AS766 Entidad Publica Empresarial Red.es','postal':'20500','timezone':'Europe/Madrid','readme':'https://ipinfo.io/missingauth'}"
     }
   }
 }

--- a/tests/templates/_sr_sched.json
+++ b/tests/templates/_sr_sched.json
@@ -1,19 +1,12 @@
 {
   "SERVERLESS_RUNTIME": {
-    "NAME": "Example Serverless Runtime",
+    "NAME": "Example Serverless Runtime with defined SCHEDULING",
     "FAAS": {
-      "CPU": 1,
-      "MEMORY": 768,
-      "DISK_SIZE": 3072,
-      "FLAVOUR": "Function",
-      "ENDPOINT": ""
+      "FLAVOUR": "Function"
     },
     "SCHEDULING": {
       "POLICY": "energy",
       "REQUIREMENTS": "energy=50"
-    },
-    "DEVICE_INFO": {
-      "GEOGRAPHIC_LOCATION": "{'ip':'193.145.247.253','city':'Arrasate / Mondragón','region':'Basque Country','country':'ES','loc':'43.0644,-2.4898','org':'AS766 Entidad Publica Empresarial Red.es','postal':'20500','timezone':'Europe/Madrid','readme':'https://ipinfo.io/missingauth'}"
     }
   }
 }


### PR DESCRIPTION
- The flavour tuple is now mapped to each function VM user template

```
onevm show 268 -j | jq .VM.USER_TEMPLATE.FLAVOURS
"Function-Data"
```
- The SCHEDULING sub properties are now translated to UPPERCASE values for VM SCHED_REQUIREMENTS and SCHED_RANK parameters.
- Fixed an issue with tuple handling where a reference was used instead of a duplicate, causing an alteration that would result in a sequential modification of the original specification every time that the tuple extraction logic would be called
