### PR TITLE
Update 1.3

### DIFF
--- a/share/api.yaml
+++ b/share/api.yaml
@@ -1,6 +1,6 @@
 openapi: "3.0.0"
 info:
-  version: "1.2.0"
+  version: "1.3.0"
   title: "Provisioning Engine REST API"
   description: Provides FaaS capabilities by leveraging features from OpenNebula. Allows to manage Serverless Runtime instances based on a group of Functions defined on request.
 

--- a/share/schemas/serverless_runtime.json
+++ b/share/schemas/serverless_runtime.json
@@ -110,8 +110,9 @@
           "description": "Information about the engine Client Device environment",
           "properties": {
             "LATENCY_TO_PE": {
-              "type": "integer",
-              "description": "Latency from the client device to the Provisioning Engine endpoint in miliseconds"
+              "type": "number",
+              "format": "float",
+              "description": "Latency from the client device to the Provisioning Engine endpoint in seconds"
             },
             "GEOGRAPHIC_LOCATION": {
               "type": "string",

--- a/src/client/client.rb
+++ b/src/client/client.rb
@@ -23,6 +23,8 @@ module ProvisionEngine
         # @param [String] endpoint where the engine is running
         # @param [String] credentials in the form of user:pass
         #
+        attr_accessor :user, :pass
+
         def initialize(endpoint, auth = nil)
             if auth.nil?
                 @user = nil

--- a/src/server/client.rb
+++ b/src/server/client.rb
@@ -5,9 +5,10 @@ module ProvisionEngine
     #
     class CloudClient
 
-        attr_accessor :conf, :client_oned, :client_oneflow, :logger
+        attr_accessor :conf, :client_oned, :client_oneflow, :logger, :auth
 
         def initialize(conf, auth)
+            @auth = auth
             @conf = conf
             @logger = ProvisionEngine::Logger.new(conf[:log], 'CloudClient')
 

--- a/src/server/function.rb
+++ b/src/server/function.rb
@@ -172,9 +172,15 @@ module ProvisionEngine
             vcpu_max = cpu * conf_capacity[:cpu][:mult]
 
             # Append Create API Call credentials to VM.CONTEXT on base64
-            context = vm_template.template_like_str("#{T}CONTEXT")
-            context << "\n#{"SR_AUTH=\"#{Base64.encode64(client.auth)}\""}"
-            context.gsub!(/"$/, '",').reverse!.sub!(',', '').reverse!
+            auth64 = "SR_AUTH=\"#{Base64.encode64(client.auth)}\""
+
+            begin
+                context = vm_template.template_like_str("#{T}CONTEXT")
+                context << "\n#{auth64}"
+                context.gsub!(/"$/, '",').reverse!.sub!(',', '').reverse!
+            rescue NoMethodError # triggers when Function VM Template has no CONTEXT defined
+                context=auth64
+            end
 
             xaas = []
 

--- a/src/server/runtime.rb
+++ b/src/server/runtime.rb
@@ -419,8 +419,7 @@ module ProvisionEngine
                             return ProvisionEngine::Error.new(500, error)
                         end
 
-                        vm_template = ProvisionEngine::Function.map_vm_template(specification[role], vm_template,
-                                                                                  client.conf[:capacity])
+                        vm_template = ProvisionEngine::Function.map_vm_template(specification[role], vm_template, client)
 
                         vm_template_contents = "#{vm_template}\n#{user_template}"
 

--- a/src/server/server.rb
+++ b/src/server/server.rb
@@ -25,7 +25,7 @@ require 'error'
 require 'runtime'
 require 'function'
 
-VERSION = '1.2.0'
+VERSION = '1.3.0'
 
 ############################################################################
 # API configuration

--- a/tests/init.rb
+++ b/tests/init.rb
@@ -6,6 +6,7 @@
 require 'json'
 require 'yaml'
 require 'securerandom'
+require 'base64'
 
 # Gems
 require 'rspec'

--- a/tests/lib/common.rb
+++ b/tests/lib/common.rb
@@ -58,6 +58,8 @@ def verify_sr_spec(specification, runtime)
             expect(runtime[role].key?(mandatory)).to be(true)
         end
 
+        expect(Base64.decode64(vm["#{T}/CONTEXT/SR_AUTH"])).to eq(@conf[:client][:engine].user + ':' + @conf[:client][:engine].pass)
+
         # optional role information exists if given
         ['CPU', 'VCPU', 'MEMORY', 'DISK_SIZE'].each do |optional|
             next unless specification[role][optional]
@@ -89,9 +91,7 @@ def verify_sr_spec(specification, runtime)
         end
 
         # Verify VM.USER_TEMPLATE
-
         expect(vm["#{UT}FLAVOURS"]).to eq(ProvisionEngine::ServerlessRuntime.tuple(specification))
-        expect(Base64.decode64(vm["#{T}/CONTEXT/SR_AUTH"])).to eq(@conf[:client][:engine].user + ':' + @conf[:client][:engine].pass)
 
         if specification.key?('SCHEDULING')
             specification['SCHEDULING'].each do |k, v|

--- a/tests/lib/common.rb
+++ b/tests/lib/common.rb
@@ -91,6 +91,7 @@ def verify_sr_spec(specification, runtime)
         # Verify VM.USER_TEMPLATE
 
         expect(vm["#{UT}FLAVOURS"]).to eq(ProvisionEngine::ServerlessRuntime.tuple(specification))
+        expect(Base64.decode64(vm["#{T}/CONTEXT/SR_AUTH"])).to eq(@conf[:client][:engine].user + ':' + @conf[:client][:engine].pass)
 
         if specification.key?('SCHEDULING')
             specification['SCHEDULING'].each do |k, v|

--- a/tests/lib/common.rb
+++ b/tests/lib/common.rb
@@ -222,6 +222,8 @@ def randomize_schevice?(specification)
         specification[SRR][schevice].each do |k, v|
             if v.is_a?(Integer)
                 specification[SRR][schevice][k] = rand(2147483647)
+            elsif v.is_a?(Float)
+                specification[SRR][schevice][k] = rand
             else
                 specification[SRR][schevice][k] = SecureRandom.alphanumeric
             end

--- a/tests/lib/crud.rb
+++ b/tests/lib/crud.rb
@@ -65,7 +65,7 @@ RSpec.shared_context 'crud' do |sr_template|
             else
                 verify_error(runtime)
 
-                raise "Unexpected error code #{rc}"
+                raise "Unexpected error code #{rc}\n#{runtime}"
             end
         end
     end

--- a/tests/templates/sr_faas_device_info.json
+++ b/tests/templates/sr_faas_device_info.json
@@ -4,7 +4,7 @@
       "FLAVOUR": "Function"
     },
     "DEVICE_INFO": {
-      "LATENCY_TO_PE": 100,
+      "LATENCY_TO_PE": 0.360587,
       "GEOGRAPHIC_LOCATION": "Madrid"
     }
   }


### PR DESCRIPTION
Store `SR.Create` API Call authentication in VM.CONTEXT.SR_AUTH encoded in base64

```json
root@pedev:~# onevm show 280 -j | jq .VM.TEMPLATE.CONTEXT
{
  "DISK_ID": "1",
  "NETWORK": "YES",
  "SR_AUTH": "b25lYWRtaW46b3Blbm5lYnVsYQ==\n",
  "SSH_PUBLIC_KEY": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDDBWCwxZyryxr1NhhJkTMQDs/8kl1Za0BB1J6rcFrjihkWuB5aVtsYq1KknOAbDqOYQODO9ZRwaYAH38AjAXUbmpZ6CDcLugkYdZ09tMoYbPLn7fd9VCJ1549Ml08uDfYhtGWakadZOGhfo48YXyinprwcxnIbWY4fyIvT/IhkkA1mJsg5vEJd+OCc8bGulCrK77mHuQH+6zYUqrGPjkpomuqruBnExh0+H1++gUSxZfGHZX383SOvlOTPhGLQ3NV7EdPuOLAxDqcNsA5BxMtRp5rMEB6bIEQyPsTwwbBGeGUKCJYynOuPMRaR1WsxHFBmERuYedCF1RFIYDIM5czrz1+mldMse3753MdoR6NHZXQqnzr2aHYhMeg9pJOEMkwUtTt/CMX7xJ6V/zArUjEH2IW59eU2fpS7LWkOwJqe5wxC+BYzfnhpalfOQCMO0nhNzcwyDDzsJ085nP/EfKTvbcW4eatsrSGR6yaiJcYOxcGluIfc+8w3Rpnqpd72tC0= oneadmin@provisionengine\nssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDAfIfpKb78xN8ECILRH2FAP9K5MP3spp5cw2tG90GCLR5gya7B59UJVGhTqJIAVQSS8M1CD1hIzMH69Prwqcp1a8zCd2oRwsaPJ2I9ExCI0sZY6RoZN5t5KW+yxoK9BB4NtcQrYKg2nIdwJNYIDjxJqh8bRbS9DauP2sNPpOx6mSQeq+xYDtrYVpS6Wu6JIy69GhnlJ4eDq4lkSouLz6HIP1Dz3T6qrELEN1ifHi4bZZRZ0bv5r3v5ALkR6L5L2lT/efE0Htvqh8kQLrYDmkKE1KbPEJVo/KqetcqMttZa1PIln7VPhifZwV37n0A3alI/U9OD/kTr5YxEo+bxDY0EwNtm6X1h0fc3Xf/7JDC3432sfFjD75eKQz6ckELawd3YdkfWfFtJf1rMsb2IT0FpywYNVkvUoEHwboN+OL57LKx3sX5mk/fXHOmrzcGYQvkR3UY7yGkPgJjaC2rxAXOaS8gltb1liPsSQgY/3VucT3XK9hbe/H9+M/++Xn1NQ4k= root@provisionengine",
  "TARGET": "hda"
}
```

Changed LATENCY_TO_PE to be float. Description mentions seconds instead of miliseconds now.

Closes #38 