### PR TITLE
Remove unnecesary check

### DIFF
--- a/share/api.yaml
+++ b/share/api.yaml
@@ -1,6 +1,6 @@
 openapi: "3.0.0"
 info:
-  version: "1.3.1"
+  version: "1.3.2"
   title: "Provisioning Engine REST API"
   description: Provides FaaS capabilities by leveraging features from OpenNebula. Allows to manage Serverless Runtime instances based on a group of Functions defined on request.
 

--- a/src/server/runtime.rb
+++ b/src/server/runtime.rb
@@ -144,7 +144,7 @@ module ProvisionEngine
             specification = specification[SRR]
 
             ProvisionEngine::Function::FUNCTIONS.each do |function|
-                next if specification[function].nil? || specification[function]['FLAVOUR'].empty? || @body[function].nil?
+                next if specification[function].nil? || @body[function].nil?
 
                 vm_id = @body[function]['VM_ID']
                 if vm_id.nil?

--- a/src/server/server.rb
+++ b/src/server/server.rb
@@ -25,7 +25,7 @@ require 'error'
 require 'runtime'
 require 'function'
 
-VERSION = '1.3.1'
+VERSION = '1.3.2'
 
 ############################################################################
 # API configuration


### PR DESCRIPTION
Removes a check that prevents an update call with empty Flavour to actually update the SR VM. For that update to happen, only the vm_id is necessary on the SR Template sent with the PUT request. Non empty Flavour is only mandatory on the POST/CREATE call.